### PR TITLE
Fix Memory Leak

### DIFF
--- a/app.js
+++ b/app.js
@@ -68,22 +68,18 @@ function secureCookies(req, res, next) {
   next();
 }
 
-function initSession(req, res, next) {
-  session({
-    store: redisStore,
-    cookie: {
-      secure: (req.protocol === 'https')
-    },
-    key: 'hmbrp.sid',
-    secret: config.session.secret,
-    resave: true,
-    saveUninitialized: true
-  })(req, res, next);
-}
-
 app.use(require('cookie-parser')(config.session.secret));
 app.use(secureCookies);
-app.use(initSession);
+app.use(session({
+  store: redisStore,
+  cookie: {
+    secure: (config.env === 'development' || config.env === 'ci') ? false : true
+  },
+  key: 'hmbrp.sid',
+  secret: config.session.secret,
+  resave: true,
+  saveUninitialized: true
+}));
 
 // apps
 app.use(require('./apps/gro/'));


### PR DESCRIPTION
- only invoke `session` function once
- don't invoke `session` function per request
- references: https://github.com/UKHomeOffice/brp_app/pull/329
