### PR TITLE
GFM-7 - Added error message for future date entered - "When did you p…

### DIFF
--- a/apps/gro/translations/src/en/validation.json
+++ b/apps/gro/translations/src/en/validation.json
@@ -44,7 +44,8 @@
   "when-date": {
     "required": "Tell us when you placed your order",
     "numeric": "Date must only contain numbers",
-    "format": "Enter the date in the correct format"
+    "format": "Enter the date in the correct format",
+    "future": "The date is in the future"
   },
   "name-text": {
     "required": "Tell us your full name"


### PR DESCRIPTION
…lace your order" step

https://jira.digital.homeoffice.gov.uk/browse/GFM-7

* Added error message "The date is in the future"
* Configured dev task to watch for file changes
* Replaced parallelshell with npm-run-all as it is now deprecated - https://github.com/mysticatea/npm-run-all/issues/10