### PR TITLE
GFM-32 - Changed travis config to use recent versions of node

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,8 @@
 language: node_js
 node_js:
-  - "0.12"
+  - "5"
+  - "4"
+  - "4.2"
 
 services:
   - redis-server
@@ -9,4 +11,12 @@ cache:
   directories:
     - node_modules
 
-script: "npm run test:ci && npm run sass; NODE_ENV='ci' npm start& npm run test:acceptance"
+before_install:
+  - rvm install 2.2.2
+
+before_script:
+  - npm run sass
+  - NODE_ENV='ci' npm start&
+
+script:
+  - npm run test:ci


### PR DESCRIPTION
https://jira.digital.homeoffice.gov.uk/browse/GFM-32

* Removed node version 0.12 and added 4, 4.2 and 5 to Travis config
* Split Travis script to separate tasks, added before_script step to run sass and start app
* Removed acceptance test step for now until migration complete