### PR TITLE
GFM-32 - Removed unnecessary config from .travis.yml

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,19 +4,6 @@ node_js:
   - "4"
   - "4.2"
 
-services:
-  - redis-server
-
 cache:
   directories:
     - node_modules
-
-before_install:
-  - rvm install 2.2.2
-
-before_script:
-  - npm run sass
-  - NODE_ENV='ci' npm start&
-
-script:
-  - npm run test:ci


### PR DESCRIPTION
https://jira.digital.homeoffice.gov.uk/browse/GFM-32

* removed `npm run sass`, `NODE_ENV='ci' npm start&` before_scripts
* removed npm run test:ci - Travis will run npm testby default
* removed `rvm install 2.2.2` - not needed if not running acceptance tests
* removed redis-server service