### PR TITLE
set it so we use common dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,18 +1,7 @@
-FROM vaijab/nodejs:0.12.7
+FROM quay.io/ukhomeofficedigital/nodejs:v4.4.2
 
-RUN dnf install -y -q git
+RUN npm install -g nodemon  
 
-RUN npm install -g nodemon
-RUN useradd -d /app app
-USER app
-
-WORKDIR /app
-COPY package.json /app/package.json
-COPY assets /app/assets
-RUN npm install
-COPY . /app
-
-USER root
+USER nodejs
 EXPOSE 8080
 CMD /app/run.sh
-


### PR DESCRIPTION
This replaced the GRO Dockerfile with the generic hod homeoffice Dockerfile.  Uses ONBUILD to standardise our repos so there's not very much login in this itself.