### PR TITLE
Fix version of node-sass to latest working version

### DIFF
--- a/package.json
+++ b/package.json
@@ -47,7 +47,7 @@
     "lodash": "3.0.1",
     "moment": "^2.10.3",
     "moment-business": "^2.0.0",
-    "node-sass": "^3.2.0",
+    "node-sass": "3.5.0-beta.1",
     "nodemailer": "^1.4.0",
     "nodemailer-smtp-transport": "^1.0.3",
     "nodemailer-stub-transport": "^1.0.0",


### PR DESCRIPTION
* node-sass is broken from version 3.5.1 onwards
* fixed to latest working version - 3.5.0-beta.1