### PR TITLE
move secret env vars to env_file and ignored secret env_file

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -6,3 +6,4 @@ apps/**/translations/**/default.json
 LICENSE.md
 README.md
 CONTRIBUTING.md
+secrets.env

--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,4 @@ Gemfile.lock
 apps/**/translations/**/default.json
 public
 .DS_Store
+secrets.env

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,5 +1,6 @@
 app:
   build: .
+  env_file: secrets.env
   environment:
     - NODE_ENV=docker
     - EMAIL_IGNORE_TLS=true


### PR DESCRIPTION
This is so we can share the docker-compose configuration (`docker-compose.yml`) without sharing secrets over the internet. The secrets file (`secrets.env`)  is ignored and not committed to git, which means the developer would be required to add it themselves or the `docker-compose build` command will fail.  
