### PR TITLE
add fourth param (next) to errorhandler

### DIFF
--- a/errors/index.js
+++ b/errors/index.js
@@ -8,7 +8,7 @@ var config = require('../config');
 var logger = require('../lib/logger');
 
 /*eslint no-unused-vars: 0*/
-module.exports = function errorHandler(err, req, res) {
+module.exports = function errorHandler(err, req, res, next) {
   /*eslint no-unused-vars: 1*/
   var content = {};
 


### PR DESCRIPTION
Express won't honour error handling middleware unless the function explicitly expects four parameters.
`function (err, req, res, next)`
So the error was not being called and error template not being loaded

Resolves GFM-39
