### PR TITLE
Add test coverage to precommit hook

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -7,3 +7,5 @@ LICENSE.md
 README.md
 CONTRIBUTING.md
 secrets.env
+coverage
+

--- a/.eslintignore
+++ b/.eslintignore
@@ -5,3 +5,4 @@ kube
 acceptance_tests
 apps/**/translations/**/default.json
 run.sh
+coverage

--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,4 @@ apps/**/translations/**/default.json
 public
 .DS_Store
 secrets.env
+coverage

--- a/.istanbul.yml
+++ b/.istanbul.yml
@@ -1,0 +1,21 @@
+instrumentation:
+  root: apps
+  extensions:
+    - .js
+  default-excludes: true
+  include-all-sources: true
+  excludes: ['**/fields/*.js', '**/index.js', '**/steps.js']
+check:
+  global:
+    statements: 80
+    lines: 80
+    branches: 80
+    functions: 80
+reporting:
+  print: summary
+  reports:
+    - html
+  dir: ./coverage
+  report-config:
+    html:
+      dir: coverage

--- a/.jscsrc.json
+++ b/.jscsrc.json
@@ -1,5 +1,5 @@
 {
   "preset": "google",
   "maximumLineLength": 120,
-  "excludeFiles": ["node_modules/**", "reports/**", "public/**/*"]
+  "excludeFiles": ["node_modules/**", "public/**/*", "coverage/**"]
 }

--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
     "lint": "eslint .",
     "copy:images": "cp -r ./assets/images ./public/",
     "style": "jscs **/*.js --config=./.jscsrc.json",
-    "quality": "plato -r -x 'node_modules|reports|test' -d reports/plato .",
+    "cover": "istanbul cover _mocha && istanbul check-coverage",
     "sass": "./node_modules/node-sass/bin/node-sass ./assets/scss/app.scss ./public/css/app.css --include-path ./node_modules",
     "create:public": "mkdir -p ./public/js ./public/css ./public/images",
     "hof-transpile": "hof-transpiler ./apps/**/translations/src -w --shared ./apps/common/translations/src",
@@ -64,6 +64,7 @@
     "eslint-plugin-mocha": "^0.2.2",
     "eslint-plugin-one-variable-per-var": "0.0.3",
     "hof-transpiler": "0.0.4",
+    "istanbul": "^0.4.3",
     "jscs": "^1.13.1",
     "mocha": "^2.2.5",
     "mocha-junit-reporter": "^1.4.0",
@@ -79,6 +80,7 @@
   "pre-commit": [
     "lint",
     "style",
-    "test"
+    "test",
+    "cover"
   ]
 }


### PR DESCRIPTION
- add istanbul (unit test code coverage tool) to scripts
- configure coverage (istanbul.yml)
- add `cover` to pre commit hooks.
- ignore coverage output

I've the set the coverage target at 80% and you can't commit unless the cover meets 80%!!!
Let's win at unit tests

`npm run cover`