### PR TITLE
add postcode auth secret

### DIFF
--- a/kube/services/environments/dev.yaml
+++ b/kube/services/environments/dev.yaml
@@ -23,6 +23,10 @@ Fn::FileData:
   encode: base64
   files:
   - ../secrets/dev/gro-form-crt
+- name: postcode_token
+  encode: base64
+  files:
+  - ../secrets/dev/postcode_token
 
 
 GRO_HTTP_PORT: 30241

--- a/kube/services/k8resources/gro/gro-rc.yaml
+++ b/kube/services/k8resources/gro/gro-rc.yaml
@@ -47,6 +47,11 @@ spec:
           value: redis
         - name: REDIS_PORT
           value: "6379"
+        - name: POSTCODE_AUTH
+          valueFrom:
+            secretKeyRef:
+              name: postcode_auth
+              key: token
         ports:
         - containerPort: 8080
 


### PR DESCRIPTION
adds postcode auth secret to the deploy scripts.  This is already pre-seeded into s3