### PR TITLE
Removed node v4 from Travis config

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,8 +1,7 @@
 language: node_js
 node_js:
   - "5"
-  - "4"
-  - "4.2"
+  - "4.4.2"
 
 services:
   - redis-server


### PR DESCRIPTION
this is because only a certain amount of agents can run concurrently so by testing 3 versions of node we sometimes double the time it takes to build (12 mins rather than 6)