### PR TITLE
Configured travis to use npm > v3 as hof > 7.0.1 is broken on npm 2 d…

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -12,6 +12,7 @@ cache:
     - node_modules
 
 before_install:
+  - if [[ `npm -v` != 3* ]]; then npm i -g npm@3; fi
   - rvm install 2.2.2
 
 before_script:


### PR DESCRIPTION
…ue to running subdep postinstall before install finished.

* check if current version is 3*, if not then install npm@3 globally

Added the following:

```bash
- if [[ `npm -v` != 3* ]]; then npm i -g npm@3; fi
```