### PR TITLE
Back links styling wrong

### DIFF
--- a/apps/common/views/layout.html
+++ b/apps/common/views/layout.html
@@ -20,7 +20,7 @@
       </p>
     </div>
     <span id="step">
-      <span>{{$step}}{{/step}}</span>
+      {{> partials-back}} <span>{{$step}}{{/step}}</span>
     </span>
     <div class="grid-row">
       {{> partials-maincontent-left}}

--- a/apps/common/views/partials/maincontent-left.html
+++ b/apps/common/views/partials/maincontent-left.html
@@ -6,7 +6,6 @@
     </header>
     {{$validationSummary}}{{/validationSummary}}
     {{$content}}{{/content}}
-    {{> partials-back}}
 
 </div>
 {{/content-outer}}


### PR DESCRIPTION
Fixed styling issue with backLinks by moving the backLink partial from the maincontent-left template to the layout template.
BEFORE:
![screen shot 2016-06-06 at 15 40 26](https://cloud.githubusercontent.com/assets/11047071/15826126/3fcc64f0-2bfe-11e6-9f5d-1c91f329ba0f.png)

AFTER:
![screen shot 2016-06-06 at 15 42 06](https://cloud.githubusercontent.com/assets/11047071/15826143/4f25f862-2bfe-11e6-80a6-f68915907dfc.png)
 
