### PR TITLE
GRO Form MigrationGFM-96 Remove `apps/common/fields`

### DIFF
--- a/apps/common/fields/index.js
+++ b/apps/common/fields/index.js
@@ -1,7 +1,0 @@
-'use strict';
-
-var _ = require('underscore');
-
-module.exports = _.extend(
-);
-

--- a/apps/gro/index.js
+++ b/apps/gro/index.js
@@ -6,11 +6,10 @@ var mixins = hof.mixins;
 var i18nFuture = hof.i18n;
 var router = require('express').Router();
 var path = require('path');
-var _ = require('underscore');
 var controllers = require('hof').controllers;
 var BaseController = controllers.base;
 
-var fields = _.extend({}, require('../common/fields/'), require('./fields/'));
+var fields = require('./fields/');
 var i18n = i18nFuture({
   path: path.resolve(__dirname, './translations/__lng__/__ns__.json')
 });


### PR DESCRIPTION
- Deleted the fields directory in the common directory. 
- Made changes to the index.js in the gro directory to reflect this changed. 
- Removed underscore from this file as it is now not being used.