### PR TITLE
Override https://github.com/UKHomeOffice/docker-nodejs to install npm 3

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,19 @@
-FROM quay.io/ukhomeofficedigital/nodejs:v4.4.2
+FROM quay.io/ukhomeofficedigital/nodejs-base:v4.4.2
 
+COPY . /app
+
+RUN npm install -g npm@3
+
+RUN yum clean all && \
+  yum update -y && \
+  yum install -y git && \
+  yum clean all && \
+  rpm --rebuilddb && \
+  rm -rf node_modules && \
+  npm --production=false install --unsafe-perm --no-optional && \
+  NODE_ENV=development npm test && \
+  npm prune --production && \
+  chown -R nodejs:nodejs .
 
 RUN npm install -g nodemon
 


### PR DESCRIPTION
- copy https://github.com/UKHomeOffice/docker-nodejs contents to GRO Dockerfile
- add `RUN npm instal -g npm@3`

Due to a change in hmpo-frontend-toolkit@4.1.0, and when we use npm 2, which runs postinstall before npm install, then the build breaks. 
This pr introduces a change to the Dockerfile that installs npm 3, which runs postinstall before install