### PR TITLE
feature - use deepTranslate middleware

### DIFF
--- a/apps/gro/index.js
+++ b/apps/gro/index.js
@@ -4,6 +4,7 @@ var hof = require('hof');
 var wizard = hof.wizard;
 var mixins = hof.mixins;
 var i18nFuture = hof.i18n;
+var deepTranslate = hof.middleware.deepTranslate;
 var router = require('express').Router();
 var path = require('path');
 var controllers = require('hof').controllers;
@@ -14,14 +15,15 @@ var i18n = i18nFuture({
   path: path.resolve(__dirname, './translations/__lng__/__ns__.json')
 });
 
-router.use(mixins(fields, {
+router.use(deepTranslate({
   translate: i18n.translate.bind(i18n)
 }));
+
+router.use(mixins(fields));
 
 router.use('/', wizard(require('./steps'), fields, {
   controller: BaseController,
   templatePath: path.resolve(__dirname, 'views'),
-  translate: i18n.translate.bind(i18n),
   params: '/:action?'
 }));
 


### PR DESCRIPTION
* applied deepTranslate middleware before mixins and wizard
* removed translate function from middleware and wizard - they will use `req.translate` if a translation method is not provided directly