### PR TITLE
GFM-116 - added manual-entry link to postcode page

### DIFF
--- a/acceptance_tests/features/postcode.feature
+++ b/acceptance_tests/features/postcode.feature
@@ -136,3 +136,9 @@ Feature: I am able to navigate through the GRO form correctly
     When I click Confirm submission
     Then I am taken to the confirmation page
 
+  Scenario: Manual postcode lookup
+    When I enter my country uk
+    Then I am taken to the postcode page of the form
+    And I can see the manual_lookup element
+    When I click on manual_lookup
+    Then I am taken to the address page of the form

--- a/acceptance_tests/features/step_definitions/shared_steps.rb
+++ b/acceptance_tests/features/step_definitions/shared_steps.rb
@@ -19,8 +19,8 @@ Then(/^I am taken to the (.*) page of the form$/) do | header |
   expect(page).to have_content CONTENT["#{header}_header"]
 end
 
-And(/^I can see the (.*) field/) do | field |
-  expect(page).to have_css "##{CONTENT["#{field}"]}"
+And(/^I can see the (.*) (?:element|field)$/) do | element |
+  expect(page).to have_css "##{CONTENT["#{element}"]}"
 end
 
 When(/^I fill in the name on the certificate$/) do
@@ -90,7 +90,7 @@ When(/^I click the back link$/) do
 end
 
 When(/^I click the cant find address link$/) do
-  click_link('I can\'t find my address in list')
+  click_link('I can\'t find my address in the list')
 end
 
 Then(/^I should see the (.*) error$/) do | type |

--- a/acceptance_tests/features/support/content.yml
+++ b/acceptance_tests/features/support/content.yml
@@ -97,6 +97,7 @@ address_summary_not_uk: '49 Yellow Brick Road Emerald City'
 address_summary_NI: '49 Yellow Brick Road Emerald City'
 address_summary_other: '49 Yellow Brick Road Emerald City'
 address_summary_not_in_MOJ: '49 Yellow Brick Road Emerald City'
+manual_lookup: 'manual-entry'
 
 confirmation_content: 'Thank you for contacting the General Register Office'
 

--- a/apps/gro/controllers/address.js
+++ b/apps/gro/controllers/address.js
@@ -3,12 +3,23 @@
 const BaseController = require('hof').controllers.base;
 
 module.exports = class AddressController extends BaseController {
+  getValues(req, res, callback) {
+    if (req.params.action === 'manual') {
+      req.sessionModel.unset([
+        'postcode-code',
+        'postcodeApiMeta'
+      ]);
+    }
+    super.getValues(req, res, callback);
+  }
+
   locals(req, res, callback) {
+    const isManual = req.params.action === 'manual';
     const locals = super.locals(req, res, callback);
     const isDomestic = req.form.values['country-select'] === 'United Kingdom';
     return Object.assign({}, locals, {
       isDomestic,
-      postcodeApiMessageKey: (req.sessionModel.get('postcodeApiMeta') || {}).messageKey
+      postcodeApiMessageKey: isManual ? '' : (req.sessionModel.get('postcodeApiMeta') || {}).messageKey
     });
   }
 };

--- a/apps/gro/fields/address.js
+++ b/apps/gro/fields/address.js
@@ -2,6 +2,7 @@
 
 module.exports = {
   'address-textarea': {
+    mixin: 'textarea',
     validate: ['required'],
     'ignore-defaults': true,
     formatter: ['trim', 'hyphens']

--- a/apps/gro/translations/src/en/pages.json
+++ b/apps/gro/translations/src/en/pages.json
@@ -11,13 +11,14 @@
   "address": {
     "header": "What is your address?",
     "edit": "Change",
-    "cantfind": "I can't find my address in list"
-  },
-  "no-postcode": {
+    "cantfind": "I can't find my address in the list",
     "postcode-api": {
       "not-found": "Sorry – we couldn’t find any addresses for that postcode, enter your address manually",
       "cant-connect": "Sorry – we couldn’t connect to the postcode lookup service at this time, enter your address manually"
     }
+  },
+  "postcode": {
+    "manual": "Enter manually"
   },
   "confirm": {
     "header": "Is the information you have given us correct?",

--- a/apps/gro/views/address.html
+++ b/apps/gro/views/address.html
@@ -1,18 +1,20 @@
 {{<partials-page}}
   {{$page-content}}
     {{#isDomestic}}
-      {{> partials-amend-postcode}}
+      {{#values.postcode-code}}
+        {{> partials-amend-postcode}}
+      {{/values.postcode-code}}
       {{#postcodeApiMessageKey}}
         <div class="alert-info">
           <span class="info-message">
-            {{#t}}pages.no-postcode.postcode-api.{{postcodeApiMessageKey}}{{/t}}
+            {{#t}}pages.address.postcode-api.{{postcodeApiMessageKey}}{{/t}}
           </span>
         </div>
       {{/postcodeApiMessageKey}}
     {{/isDomestic}}
-
-    {{#textarea}}address-textarea{{/textarea}}
-    
+    {{#fields}}
+      {{#renderField}}{{/renderField}}
+    {{/fields}}
     {{#input-submit}}continue{{/input-submit}}
   {{/page-content}}
 {{/partials-page}}

--- a/apps/gro/views/postcode.html
+++ b/apps/gro/views/postcode.html
@@ -1,0 +1,13 @@
+{{<partials-page}}
+  {{$page-content}}
+    <p>
+      <span class="link">
+        <a id='manual-entry' href="{{baseUrl}}/address/manual">{{#t}}pages.postcode.manual{{/t}}</a>
+      </span>
+    </p>
+    {{#fields}}
+      {{#renderField}}{{/renderField}}
+    {{/fields}}
+    {{#input-submit}}continue{{/input-submit}}
+  {{/page-content}}
+{{/partials-page}}


### PR DESCRIPTION
* added link to postcode page, uses action: manual
* amended address page to not show amend postcode link if not defined
* unset postcode on address step if manual link was clicked
* fix bug with address error not showing
* added to acceptance tests