### PR TITLE
Fix middleware implemetnation

### DIFF
--- a/app.js
+++ b/app.js
@@ -8,6 +8,9 @@ const churchill = require('churchill');
 const session = require('express-session');
 const redis = require('redis');
 const config = require('./config');
+const i18n = require('hof').i18n({
+  path: path.resolve(__dirname, './apps/common/translations/__lng__/__ns__.json')
+});
 
 if (config.env === 'ci') {
   app.use(require('./ci.js'));
@@ -78,18 +81,28 @@ app.use(session({
   saveUninitialized: true
 }));
 
+// check for cookies
+app.use(require('hof').middleware.cookies());
+
 // apps
 app.use(require('./apps/gro/'));
 
 app.get('/cookies', (req, res) => res.render('cookies'));
 app.get('/terms-and-conditions', (req, res) => res.render('terms'));
+
+// shallow health check
 app.get('/healthz/ping', (req, res) => res.send(200));
+
+// 404's
+app.use(require('hof').middleware.notFound({
+  logger: require('./lib/logger'),
+  translate: i18n.translate.bind(i18n),
+}));
 
 // errors
 app.use(require('hof').middleware.errors({
   logger: require('./lib/logger'),
-  translate: require('hof').i18n.translate,
-  debug: config.env === 'development'
+  translate: i18n.translate.bind(i18n)
 }));
 
 // eslint-disable-next-line camelcase

--- a/apps/common/translations/src/en/errors.json
+++ b/apps/common/translations/src/en/errors.json
@@ -5,6 +5,14 @@
   },
   "session": {
     "title": "Sorry, you'll have to start again",
-    "message": "You haven't entered any details for 20 minutes, so we have cleared your information to keep it secure."
+    "message": "You haven't entered any details for 30 minutes, so we have cleared your information to keep it secure."
+  },
+  "404": {
+    "title": "Page not found",
+    "description": "This page does not exist"
+  },
+  "cookies-required": {
+    "title": "Cookies are required to use this service",
+    "message": "Cookies are required in order to use the BRP service.<br /><br /> Please <a href=\"http://www.aboutcookies.org/how-to-control-cookies/\" rel=\"external\">enable cookies</a> and try again. Find out <a href=\"/cookies\">how to we use cookies</a>."
   }
 }

--- a/apps/common/views/404.html
+++ b/apps/common/views/404.html
@@ -1,0 +1,12 @@
+{{<layout}}
+
+{{$header}}
+  {{title}}
+{{/header}}
+
+{{$content}}
+  <p>{{description}}</p>
+  <a href="/" class="button" role="button">Start again</a>
+{{/content}}
+
+{{/layout}}

--- a/apps/common/views/error.html
+++ b/apps/common/views/error.html
@@ -5,8 +5,8 @@
 {{/header}}
 
 {{$content}}
-    <p>{{content.message}}</p>
-    <a href="/{{startLink}}" class="button" role="button">Start again</a>
+    <p>{{{content.message}}}</p>
+    <a href="/" class="button" role="button">Start again</a>
     {{#showStack}}
       <pre>
         {{error.stack}}


### PR DESCRIPTION
- invoke i18n with a path to the translations before assigning translate
- use hof cookie middleware before alls routes
- use not found middleware before error handler
- don't pass debug to error handler; we want to see the translations
- add cookie and not found translations to the translations file
- add a 404 template
- make start link a slash.