### PR TITLE
Fix up multiple issues with the build:

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,21 +1,28 @@
 FROM quay.io/ukhomeofficedigital/nodejs-base:v4.4.2
 
-COPY . /app
-
-RUN npm install -g npm@3
+RUN mkdir /public
 
 RUN yum clean all && \
   yum update -y && \
   yum install -y git && \
-  yum clean all && \
-  rpm --rebuilddb && \
-  rm -rf node_modules && \
-  npm --production=false install --unsafe-perm --no-optional && \
-  npm test && \
-  npm prune --production && \
-  chown -R nodejs:nodejs .
+  yum clean all
+
+RUN rpm --rebuilddb
+
+RUN npm install -g npm@3
+
+COPY package.json /app/package.json
+
+WORKDIR /app
 
 USER nodejs
 
-EXPOSE 8080
+RUN npm install --production --no-optional
+
+COPY . /app
+
+USER root
+
+RUN npm run postinstall
+
 CMD /app/run.sh

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -3,7 +3,7 @@
 def build() {
     node {
         checkout scm
-        sh 'docker build . | tee build.log || exit 1; ID=$(tail -1 build.log | awk \'{print $3;}\'); echo $ID > DOCKER_HASH'
+        sh '((docker build . | tee build.log) || exit 1) && ID=$(tail -1 build.log | awk \'{print $3;}\') && echo $ID > DOCKER_HASH'
         docker_hash=readFile('DOCKER_HASH').trim()
 
         sh "git rev-parse --short HEAD > GIT_COMMIT"
@@ -52,7 +52,3 @@ stage "Run End-to-End"
 stage "Promote to Preprod"
     input "Are you Sure?"
     deploy('preprod', app_tag)
-
-stage "Promote to Production"
-    input "Are you Sure?"
-    deploy('prod', app_tag)

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -12,13 +12,13 @@ services:
       - REDIS_HOST=redis
       - REDIS_PORT=6379
       # - DEBUG=email
-    volumes:
-      - "/public"
     links:
       - redis
       - maildev
     ports:
       - "8080:8080"
+    volumes:
+      - "/public"
   redis:
     image: redis
 
@@ -30,12 +30,12 @@ services:
       - NAXSI_USE_DEFAULT_RULES=FALSE
       - ADD_NGINX_SERVER_CFG=add_header Cache-Control private;add_header X-Frame-Options "SAMEORIGIN" always;add_header X-Content-Type-Options "nosniff" always;add_header X-XSS-Protection "1; mode=block" always;location /public {add_header Cache-Control max-age=86400;add_header X-Frame-Options "SAMEORIGIN" always;add_header X-Content-Type-Options "nosniff" always;add_header X-XSS-Protection "1; mode=block" always;alias /public;}
       - ERROR_REDIRECT_CODES=599
-    volumes:
-      - ./public:/public
     ports:
       - "443:443"
       - "80:80"
     links:
+      - app
+    volumes_from:
       - app
 
   maildev:

--- a/kube/services/k8resources/gro/gro-rc.yaml
+++ b/kube/services/k8resources/gro/gro-rc.yaml
@@ -30,7 +30,7 @@ spec:
         - name: NAXSI_USE_DEFAULT_RULES
           value: "FALSE"
         - name: ERROR_REDIRECT_CODES
-          value: 599
+          value: "599"
         - name: ADD_NGINX_SERVER_CFG
           value: |
             add_header Cache-Control private;
@@ -48,6 +48,8 @@ spec:
           - name: external-tls
             mountPath: /etc/keys
             readOnly: true
+          - mountPath: /public
+            name: public
       - name: app
         image: quay.io/ukhomeofficedigital/gro-form:${app_tag}
         imagePullPolicy: Always
@@ -69,7 +71,14 @@ spec:
           value: "6379"
         ports:
         - containerPort: 8080
+        command:
+          - "/app/run.sh"
+        volumeMounts:
+        - mountPath: /public
+          name: public
       volumes:
         - name: external-tls
           secret:
             secretName: external-tls
+        - name: public
+          emptyDir: {}

--- a/package.json
+++ b/package.json
@@ -28,7 +28,8 @@
     "sass": "node-sass ./assets/scss/app.scss ./public/css/app.css --include-path ./node_modules",
     "create:public": "mkdir -p ./public/js ./public/css ./public/images",
     "hof-transpile": "hof-transpiler ./apps/**/translations/src -w --shared ./apps/common/translations/src",
-    "postinstall": "npm run create:public; npm run sass; npm run browserify; npm run copy:images; npm run hof-transpile"
+    "prepareapp": "npm run create:public; npm run sass; npm run browserify; npm run copy:images; npm run hof-transpile",
+    "postinstall": "bash -c 'if [[ ${NODE_ENV} != production ]]; then npm run prepareapp; fi;'"
   },
   "author": "HomeOffice",
   "dependencies": {
@@ -40,7 +41,7 @@
     "express": "^4.12.4",
     "express-partial-templates": "^0.1.0",
     "express-session": "^1.11.3",
-    "hof": "https://github.com/UKHomeOffice/hof.git#so-master",
+    "hof": "UKHomeOffice/hof#so-master",
     "hogan-express-strict": "^0.5.4",
     "hogan.js": "^3.0.2",
     "i18n-lookup": "^0.1.0",
@@ -52,12 +53,12 @@
     "nodemailer-stub-transport": "^1.0.0",
     "redis": "^0.12.1",
     "typeahead-aria": "^1.0.1",
-    "winston": "^1.0.1"
+    "winston": "^1.0.1",
+    "hof-transpiler": "0.0.4"
   },
   "devDependencies": {
     "chai": "^3.0.0",
     "debug": "^2.2.0",
-    "hof-transpiler": "0.0.4",
     "istanbul": "^0.4.3",
     "jscs": "^1.13.1",
     "mocha": "^2.2.5",

--- a/run.sh
+++ b/run.sh
@@ -5,5 +5,7 @@ then echo "starting service"
   SITEROOT=/gro GA_TAG_ID=UA-72527484-1
 fi
 
-exec node app.js
+cp -r /app/public/* /public/
+
+su nodejs -c 'exec node app.js'
 


### PR DESCRIPTION
* Quote ports and error codes to make yaml parsers happy in the kube controller
* Fix /public serving issue
  Ensure docker file creates a public dir and moves files into it
  Refactor docker file to cache more build steps.
  Remove the need for tests in our docker file (this should be done outside of here)
* Make docker-compose reflect kubernetes better
* Add /public mount points in kubernetes for the nginx proxy
* Ensure public can be shared in kubernetes.
  Sadly kube doesn't have a volumes-from feature like in compose so you have to do something yucky like making an emptyDir then copying the files in from a shell script :(
* Our build shouldn't be one giant pipeline.
  It should have other builds to do this else we literally never get a green build unless we deploy to prod (lulz).
* Fix jenkins build
  The previous version was taking the previous build hash. This should wait for the build to finish before it gets the docker hash
* Make dockerfile cache node_modules better to speed up builds.