### PR TITLE
Feature/docker travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,18 +2,18 @@ language: node_js
 node_js:
   - "5"
   - "4.4.2"
+cache: bundler
 
 services:
-  - redis-server
+  - docker
 
 before_install:
+  - rvm install 2.2.2
+  - gem install bundler
   - if [[ `npm -v` != 3* ]]; then npm i -g npm@3; fi
   - npm cache clean
-  - rvm install 2.2.2
-
-before_script:
-  - npm run sass
-  - NODE_ENV='ci' npm start&
+  - docker build --tag travis .
+  - docker run -d -p 127.0.0.1:8080:8080 -e NODE_ENV=ci travis
 
 script:
   -  npm run test:ci && npm run test:acceptance

--- a/app.js
+++ b/app.js
@@ -6,7 +6,6 @@ const path = require('path');
 const logger = require('./lib/logger');
 const churchill = require('churchill');
 const session = require('express-session');
-const redis = require('redis');
 const config = require('./config');
 const mockAPI = require('./ci.js');
 const expressPartialTemplates = require('express-partial-templates');
@@ -15,7 +14,7 @@ const bodyParser = require('body-parser');
 const connectRedisCrypto = require('connect-redis-crypto');
 const cookieParser = require('cookie-parser');
 const gro = require('./apps/gro/');
-
+let sessionStore;
 const i18n = hof.i18n({
   path: path.resolve(__dirname, './apps/common/translations/__lng__/__ns__.json')
 });
@@ -58,31 +57,34 @@ i18n.on('ready', () => {
   // Trust proxy for secure cookies
   app.set('trust proxy', 1);
 
-  // Redis session storage
-  const RedisStore = connectRedisCrypto(session);
-  const client = redis.createClient(config.redis.port, config.redis.host);
+  if (config.env !== 'ci') {
+    // Redis session storage
+    const redis = require('redis');
+    const RedisStore = require('connect-redis-crypto')(session);
+    const client = redis.createClient(config.redis.port, config.redis.host);
 
-  client.on('connecting', () => {
-    logger.info('Connecting to redis');
-  });
+    client.on('connecting', () => {
+      logger.info('Connecting to redis');
+    });
 
-  client.on('connect', () => {
-    logger.info('Connected to redis');
-  });
+    client.on('connect', () => {
+      logger.info('Connected to redis');
+    });
 
-  client.on('reconnecting', () => {
-    logger.info('Reconnecting to redis');
-  });
+    client.on('reconnecting', () => {
+      logger.info('Reconnecting to redis');
+    });
 
-  client.on('error', (e) => {
-    logger.error(e);
-  });
+    client.on('error', (e) => {
+      logger.error(e);
+    });
 
-  const redisStore = new RedisStore({
-    client,
-    ttl: config.session.ttl,
-    secret: config.session.secret
-  });
+    sessionStore = new RedisStore({
+      client,
+      ttl: config.session.ttl,
+      secret: config.session.secret
+    });
+  }
 
   function secureCookies(req, res, next) {
     const cookie = res.cookie.bind(res);
@@ -100,7 +102,7 @@ i18n.on('ready', () => {
   app.use(secureCookies);
 
   const sessionOpts = Object.assign({
-    store: redisStore,
+    store: sessionStore,
     name: config.session.name,
     cookie: {secure: config.protocol === 'https'},
     secret: config.session.secret,

--- a/app.js
+++ b/app.js
@@ -60,7 +60,7 @@ i18n.on('ready', () => {
   if (config.env !== 'ci') {
     // Redis session storage
     const redis = require('redis');
-    const RedisStore = require('connect-redis-crypto')(session);
+    const RedisStore = connectRedisCrypto(session);
     const client = redis.createClient(config.redis.port, config.redis.host);
 
     client.on('connecting', () => {


### PR DESCRIPTION
Migrate travis build to use the docker service.

I've updated our app to use in memory session store when the env var of CI is set. This allows us to have a fully isolated container which means we can run our acceptance tests against a proper REAL container in travis.