### PR TITLE
Added letsencrypt TLS.

### DIFF
--- a/kube/services/environments/dev.yaml
+++ b/kube/services/environments/dev.yaml
@@ -28,6 +28,4 @@ Fn::FileData:
   files:
   - ../secrets/dev/postcode_token
 
-
-GRO_HTTP_PORT: 30241
-GRO_HTTPS_PORT: 30242
+external_url: gro-dev.notprod.homeoffice.gov.uk

--- a/kube/services/environments/preprod.yaml
+++ b/kube/services/environments/preprod.yaml
@@ -27,5 +27,4 @@ Fn::FileData:
   files:
   - ../secrets/preprod/postcode_token
 
-GRO_HTTP_PORT: 30243
-GRO_HTTPS_PORT: 30244
+external_url: gro-preprod.notprod.homeoffice.gov.uk

--- a/kube/services/environments/prod.yaml
+++ b/kube/services/environments/prod.yaml
@@ -27,6 +27,4 @@ Fn::FileData:
   files:
   - ../secrets/prod/postcode_token
 
-
-GRO_HTTP_PORT: 30241
-GRO_HTTPS_PORT: 30242
+external_url: www.gro-certificate-enquiry.homeoffice.gov.uk

--- a/kube/services/environments/prod.yaml
+++ b/kube/services/environments/prod.yaml
@@ -27,4 +27,4 @@ Fn::FileData:
   files:
   - ../secrets/prod/postcode_token
 
-external_url: www.gro-certificate-enquiry.homeoffice.gov.uk
+external_url: gro-certificate-enquiry.homeoffice.gov.uk

--- a/kube/services/k8resources/gro/external-tls.yaml
+++ b/kube/services/k8resources/gro/external-tls.yaml
@@ -1,8 +1,0 @@
-apiVersion: v1
-kind: Secret
-metadata:
-  name: "external-tls"
-type: "Opaque"
-data:
-  key: ${ tls_key }
-  crt: ${ tls_crt }

--- a/kube/services/k8resources/gro/gro-ingress.yaml
+++ b/kube/services/k8resources/gro/gro-ingress.yaml
@@ -1,0 +1,20 @@
+apiVersion: extensions/v1beta1
+kind: Ingress
+metadata:
+  annotations:
+    kubernetes.io/tls-acme: "true"
+    ingress.kubernetes.io/secure-backends: "true"
+  name: example
+spec:
+  rules:
+  - host: ${external_url}
+    http:
+      paths:
+      - backend:
+          serviceName: gro
+          servicePort: 443
+        path: /
+  tls:
+  - hosts:
+    - ${external_url}
+    secretName: letsencrypt-tls

--- a/kube/services/k8resources/gro/gro-ingress.yaml
+++ b/kube/services/k8resources/gro/gro-ingress.yaml
@@ -14,7 +14,15 @@ spec:
           serviceName: gro
           servicePort: 443
         path: /
+  - host: www.${external_url}
+    http:
+      paths:
+      - backend:
+          serviceName: gro
+          servicePort: 443
+        path: /
   tls:
   - hosts:
     - ${external_url}
+    - www.${external_url}
     secretName: letsencrypt-tls

--- a/kube/services/k8resources/gro/gro-rc.yaml
+++ b/kube/services/k8resources/gro/gro-rc.yaml
@@ -19,8 +19,6 @@ spec:
         - containerPort: 443
         - containerPort: 80
         env:
-        - name: LOAD_BALANCER_CIDR
-          value: '10.50.0.0/22'
         - name: PROXY_SERVICE_HOST
           value: 127.0.0.1
         - name: PROXY_SERVICE_PORT
@@ -44,12 +42,45 @@ spec:
               add_header X-XSS-Protection "1; mode=block" always;
               alias /public;
             }
+        - name: SSL_CERT
+          value: /etc/secrets/tls-bundle.pem
+        - name: SSL_KEY
+          value: /etc/secrets/tls-key.pem
         volumeMounts:
-          - name: external-tls
-            mountPath: /etc/keys
-            readOnly: true
           - mountPath: /public
             name: public
+          - name: certs
+            mountPath: /etc/secrets
+            readOnly: true
+      - name: vault-side-kick
+        image: quay.io/ukhomeofficedigital/vault-sidekick-jks:v0.2.0
+        imagePullPolicy: Always
+        resources:
+          limits:
+            memory: "100Mi"
+            cpu: 100m
+          requests:
+            memory: "50Mi"
+            cpu: 100m
+        args:
+          - -output=/etc/secrets
+          - -tls-skip-verify=true
+          - -cn=pki:services/$NAMESPACE/pki/issue/default:common_name=gro.${NAMESPACE}.svc.cluster.local,file=/etc/keystore/tls,fmt=bundle
+        env:
+          - name: VAULT_ADDR
+            value: "https://vault.vault.svc.cluster.local:8200"
+          - name: VAULT_TOKEN
+            valueFrom:
+              secretKeyRef:
+                name: store-token
+                key: token
+          - name: NAMESPACE
+            valueFrom:
+              fieldRef:
+                fieldPath: metadata.namespace
+        volumeMounts:
+          - mountPath: /etc/keystore             
+            name: certs
       - name: app
         image: quay.io/ukhomeofficedigital/gro-form:${app_tag}
         imagePullPolicy: Always
@@ -77,8 +108,7 @@ spec:
         - mountPath: /public
           name: public
       volumes:
-        - name: external-tls
-          secret:
-            secretName: external-tls
         - name: public
           emptyDir: {}
+        - emptyDir: {}
+          name: certs

--- a/kube/services/k8resources/gro/gro-svc.yaml
+++ b/kube/services/k8resources/gro/gro-svc.yaml
@@ -5,15 +5,12 @@ metadata:
    name: gro
  name: gro
 spec:
- type: NodePort
  ports:
    - name: http
      port: 80
      targetPort: 80
-     nodePort: ${GRO_HTTP_PORT}
    - name: https
      port: 443
      targetPort: 443
-     nodePort: ${GRO_HTTPS_PORT}
  selector:
    name: gro


### PR DESCRIPTION
These changes help us do letsencrypt tls instead of the wildcard, which means once promoted to production you'll get the certificate you've been asking for.  This makes adding services self-service, with exception that on prod you need someone from the devops team to point your DNS name to the cluster.  Given you've already been setup on dev to use the older method, this is likely going to be a breaking change and you'll want some devops help when you deploy
