### PR TITLE
GFM-172 - lookup radio options labels implicitly

### DIFF
--- a/apps/gro/fields/about.js
+++ b/apps/gro/fields/about.js
@@ -5,24 +5,13 @@ module.exports = {
     mixin: 'radio-group',
     validate: ['required'],
     className: ['block', 'form-group'],
-    options: [{
-      value: 'not-received',
-      label: 'fields.about-radio.options.not-received.label'
-    }, {
-      value: 'wrong-certificate',
-      label: 'fields.about-radio.options.wrong-certificate.label'
-    }, {
-      value: 'damaged',
-      label: 'fields.about-radio.options.damaged.label'
-    }, {
-      value: 'refund',
-      label: 'fields.about-radio.options.refund.label'
-    }, {
-      value: 'complaint',
-      label: 'fields.about-radio.options.complaint.label'
-    }, {
-      value: 'other',
-      label: 'fields.about-radio.options.other.label'
-    }]
+    options: [
+      'not-received',
+      'wrong-certificate',
+      'damaged',
+      'refund',
+      'complaint',
+      'other'
+    ]
   }
 };

--- a/apps/gro/fields/additional.js
+++ b/apps/gro/fields/additional.js
@@ -19,12 +19,9 @@ module.exports = {
     mixin: 'radio-group',
     validate: ['required'],
     className: ['inline', 'form-group'],
-    options: [{
-      value: 'yes',
-      label: 'Yes'
-    }, {
-      value: 'no',
-      label: 'No'
-    }]
+    options: [
+      'yes',
+      'no'
+    ]
   }
 };

--- a/apps/gro/fields/details.js
+++ b/apps/gro/fields/details.js
@@ -11,24 +11,18 @@ module.exports = {
     mixin: 'radio-group',
     validate: ['required'],
     className: ['inline', 'form-group'],
-    options: [{
-      value: 'yes',
-      label: 'Yes'
-    }, {
-      value: 'no',
-      label: 'No'
-    }]
+    options: [
+      'yes',
+      'no'
+    ]
   },
   'previous-radio': {
     mixin: 'radio-group',
     validate: ['required'],
     className: ['inline', 'form-group'],
-    options: [{
-      value: 'yes',
-      label: 'Yes'
-    }, {
-      value: 'no',
-      label: 'No'
-    }]
+    options: [
+      'yes',
+      'no'
+    ]
   }
 };

--- a/apps/gro/fields/how.js
+++ b/apps/gro/fields/how.js
@@ -6,12 +6,10 @@ module.exports = {
     className: ['block', 'form-group'],
     options: [{
       value: 'online',
-      label: 'fields.how-radio.options.online.label',
       toggle: 'online-toggle-text',
       child: 'input-text'
     }, {
       value: 'telephone',
-      label: 'fields.how-radio.options.telephone.label',
       toggle: 'telephone-toggle-text',
       child: `<div id='telephone-toggle-text-panel'>
                 <div class='panel-indent'>
@@ -21,7 +19,8 @@ module.exports = {
               </div>`
     }, {
       value: 'post',
-      label: 'fields.how-radio.options.post.label'
+      toggle: 'post-toggle-text',
+      child: 'input-text'
     }]
   },
   'online-toggle-text': {},

--- a/apps/gro/fields/type.js
+++ b/apps/gro/fields/type.js
@@ -5,21 +5,12 @@ module.exports = {
     mixin: 'radio-group',
     validate: ['required'],
     className: ['block', 'form-group'],
-    options: [{
-      value: 'birth',
-      label: 'fields.type-radio.options.birth.label'
-    }, {
-      value: 'marriage',
-      label: 'fields.type-radio.options.marriage.label'
-    }, {
-      value: 'death',
-      label: 'fields.type-radio.options.death.label'
-    }, {
-      value: 'adoption',
-      label: 'fields.type-radio.options.adoption.label'
-    }, {
-      value: 'partnership',
-      label: 'fields.type-radio.options.partnership.label'
-    }]
+    options: [
+      'birth',
+      'marriage',
+      'death',
+      'adoption',
+      'partnership'
+    ]
   }
 };

--- a/apps/gro/fields/which.js
+++ b/apps/gro/fields/which.js
@@ -5,12 +5,9 @@ module.exports = {
     mixin: 'radio-group',
     validate: ['required'],
     className: ['block', 'form-group'],
-    options: [{
-      value: 'standard',
-      label: 'fields.which-radio.options.standard.label'
-    }, {
-      value: 'priority',
-      label: 'fields.which-radio.options.priority.label'
-    }]
+    options: [
+      'standard',
+      'priority'
+    ]
   }
 };

--- a/apps/gro/translations/src/en/fields.json
+++ b/apps/gro/translations/src/en/fields.json
@@ -56,6 +56,14 @@
         "complaint": "Is your complaint about an existing order?"
       },
       "default": "Is your enquiry about an existing order?"
+    },
+    "options": {
+      "yes": {
+        "label": "Yes"
+      },
+      "no": {
+        "label": "No"
+      }
     }
   },
   "previous-radio": {
@@ -64,6 +72,14 @@
         "complaint": "Have you already complained about this issue?"
       },
       "default": "Have you previously been in contact about this?"
+    },
+    "options": {
+      "yes": {
+        "label": "Yes"
+      },
+      "no": {
+        "label": "No"
+      }
     }
   },
   "person-text": {
@@ -88,7 +104,15 @@
     "label": "Whose name(s), including any middle names, is on the certificate you received?"
   },
   "additional-radio": {
-    "legend": "Have you previously been in contact about this enquiry?"
+    "legend": "Have you previously been in contact about this enquiry?",
+    "options": {
+      "yes": {
+        "label": "Yes"
+      },
+      "no": {
+        "label": "No"
+      }
+    }
   },
   "how-radio": {
     "legend": "How did you place your order?",


### PR DESCRIPTION
Due to an enhancement in hmpo-template-mixins, radio options are now looked up automatically if located at the correct path within translations

* removed all explicit label paths
* added missing labels to translations