### PR TITLE
bugfix - GFM-174 - display labels in confirm table

### DIFF
--- a/apps/gro/confirm-step-config.js
+++ b/apps/gro/confirm-step-config.js
@@ -1,11 +1,23 @@
 'use strict';
 
+const _ = require('lodash');
+
+function getLabelFromValue(value, req) {
+  return req.translate(`fields[${this.name}].options[${value}].label`);
+}
+
+const radioFields = [
+  'about-radio',
+  'type-radio',
+  'additional-radio',
+  'existing-radio',
+  'previous-radio',
+  'how-radio',
+  'which-radio'
+];
+
 module.exports = {
-  modifiers: {
-    'about-radio': function translateValue(value, req) {
-      return req.translate(`fields[${this.name}].options[${value}].label`);
-    }
-  },
+  modifiers: _.zipObject(radioFields, _.map(radioFields, () => getLabelFromValue)),
   tableSections: [{
     name: 'enquiry-details',
     fields: [


### PR DESCRIPTION
we were previously displaying the values from radios which are lowercase and hyphenated.

* added modifier lookup function to all radio fields