### PR TITLE
Task/gfm 187/waf tweaks

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -22,11 +22,11 @@ services:
     image: redis
 
   nginx-proxy:
-    image: quay.io/ukhomeofficedigital/nginx-proxy:v1.2.3
+    image: quay.io/ukhomeofficedigital/nginx-proxy-govuk:v2.0.2.0
     environment:
+      - EXTRA_NAXSI_RULES=BasicRule wl:1001,1002,1008,1009,1013 "mz:BODY"; BasicRule wl:1002,1005,1007,1010,1011,1315 "mz:$HEADERS_VAR";
       - PROXY_SERVICE_HOST=app
       - PROXY_SERVICE_PORT=8080
-      - NAXSI_USE_DEFAULT_RULES=FALSE
       - ADD_NGINX_SERVER_CFG=add_header Cache-Control private;add_header X-Frame-Options "SAMEORIGIN" always;add_header X-Content-Type-Options "nosniff" always;add_header X-XSS-Protection "1; mode=block" always;location /public {add_header Cache-Control max-age=86400;add_header X-Frame-Options "SAMEORIGIN" always;add_header X-Content-Type-Options "nosniff" always;add_header X-XSS-Protection "1; mode=block" always;alias /public;}
       - ERROR_REDIRECT_CODES=599
     ports:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -24,7 +24,7 @@ services:
   nginx-proxy:
     image: quay.io/ukhomeofficedigital/nginx-proxy-govuk:v2.0.2.0
     environment:
-      - EXTRA_NAXSI_RULES=BasicRule wl:1001,1002,1008,1009,1013 "mz:BODY"; BasicRule wl:1002,1005,1007,1010,1011,1315 "mz:$HEADERS_VAR";
+      - EXTRA_NAXSI_RULES=BasicRule wl:1001,1002,1008,1009,1013,1015 "mz:BODY"; BasicRule wl:1002,1005,1007,1010,1011,1315 "mz:$HEADERS_VAR";
       - PROXY_SERVICE_HOST=app
       - PROXY_SERVICE_PORT=8080
       - ADD_NGINX_SERVER_CFG=add_header Cache-Control private;add_header X-Frame-Options "SAMEORIGIN" always;add_header X-Content-Type-Options "nosniff" always;add_header X-XSS-Protection "1; mode=block" always;location /public {add_header Cache-Control max-age=86400;add_header X-Frame-Options "SAMEORIGIN" always;add_header X-Content-Type-Options "nosniff" always;add_header X-XSS-Protection "1; mode=block" always;alias /public;}


### PR DESCRIPTION
WAF tweaks for docker-compose to allow double quotes and commas in address selection