### PR TITLE
bugfix GFM-195 - confirm page address change link broken

### DIFF
--- a/acceptance_tests/features/alternate_content.feature
+++ b/acceptance_tests/features/alternate_content.feature
@@ -38,7 +38,7 @@ Feature: I am shown different content depending on previous answers
       |  table_not_received         |  wrong_certificate_summary  |
       |  table_type                 |  birth_summary              |
       |  table_person_text          |  full_name                  |
-      |  table_additional_names     |  additional_fullname         |
+      |  table_additional_names     |  additional_fullname        |
       |  table_additional_text      |  free_text                  |
       |  table_additional_radio     |  yes_summary                |
       |  table_which                |  standard_summary           |
@@ -46,6 +46,6 @@ Feature: I am shown different content depending on previous answers
       |  table_name                 |  full_name                  |
       |  table_email                |  email_address              |
       |  table_country              |  country_summary            |
-      |  table_post                 |  address_summary            |
+      |  table_post_select          |  address_select_summary     |
     When I click Confirm submission
     Then I am taken to the confirmation page

--- a/acceptance_tests/features/change_answers.feature
+++ b/acceptance_tests/features/change_answers.feature
@@ -20,14 +20,14 @@ Feature: I am able to change my answers and correctly navigate through the form
     When I select my address
     Then I am taken to the confirm page of the form
     Then I should see the headers and my information in the summary:
-      |  table_not_received         |  complaint_summary  |
-      |  table_details              |  free_text          |
-      |  table_existing             |  no_summary         |
-      |  table_previous             |  no_summary         |
-      |  table_name                 |  full_name          |
-      |  table_email                |  email_address      |
-      |  table_country              |  country_summary    |
-      |  table_post                 |  address_summary    |
+      |  table_not_received         |  complaint_summary      |
+      |  table_details              |  free_text              |
+      |  table_existing             |  no_summary             |
+      |  table_previous             |  no_summary             |
+      |  table_name                 |  full_name              |
+      |  table_email                |  email_address          |
+      |  table_country              |  country_summary        |
+      |  table_post                 |  address_select_summary |
     When I click change about from the about page
     Then I am taken to the about page of the form
     When I click not_received and then continue
@@ -58,17 +58,17 @@ Feature: I am able to change my answers and correctly navigate through the form
     When I select my address
     Then I am taken to the confirm page of the form
     Then I should see the headers and my information in the summary:
-      |  table_not_received         |  not_received_summary  |
-      |  table_type                 |  birth_summary         |
-      |  table_person_text          |  full_name             |
-      |  table_additional_text      |  free_text             |
-      |  table_additional_radio     |  yes_summary           |
-      |  table_which                |  standard_summary      |
-      |  table_when                 |  date_summary          |
-      |  table_name                 |  full_name             |
-      |  table_email                |  email_address         |
-      |  table_country              |  country_summary       |
-      |  table_post                 |  address_summary       |
+      |  table_not_received         |  not_received_summary   |
+      |  table_type                 |  birth_summary          |
+      |  table_person_text          |  full_name              |
+      |  table_additional_text      |  free_text              |
+      |  table_additional_radio     |  yes_summary            |
+      |  table_which                |  standard_summary       |
+      |  table_when                 |  date_summary           |
+      |  table_name                 |  full_name              |
+      |  table_email                |  email_address          |
+      |  table_country              |  country_summary        |
+      |  table_post                 |  address_select_summary |
 
   @type @debug
   Scenario: Change details text but not the path through the form
@@ -89,28 +89,28 @@ Feature: I am able to change my answers and correctly navigate through the form
     When I select my address
     Then I am taken to the confirm page of the form
     Then I should see the headers and my information in the summary:
-      |  table_not_received         |  complaint_summary  |
-      |  table_details              |  free_text          |
-      |  table_existing             |  no_summary         |
-      |  table_previous             |  no_summary         |
-      |  table_name                 |  full_name          |
-      |  table_email                |  email_address      |
-      |  table_country              |  country_summary    |
-      |  table_post                 |  address_summary    |
+      |  table_not_received         |  complaint_summary      |
+      |  table_details              |  free_text              |
+      |  table_existing             |  no_summary             |
+      |  table_previous             |  no_summary             |
+      |  table_name                 |  full_name              |
+      |  table_email                |  email_address          |
+      |  table_country              |  country_summary        |
+      |  table_post                 |  address_select_summary |
     When I click change details_text from the details page
     Then I am taken to the details_complaint page of the form
     When I change details_text to alt_text
     When I click continue
     Then I am taken to the confirm page of the form
     Then I should see the headers and my information in the summary:
-      |  table_not_received         |  complaint_summary  |
-      |  table_details              |  alt_text           |
-      |  table_existing             |  no_summary         |
-      |  table_previous             |  no_summary         |
-      |  table_name                 |  full_name          |
-      |  table_email                |  email_address      |
-      |  table_country              |  country_summary    |
-      |  table_post                 |  address_summary    |
+      |  table_not_received         |  complaint_summary      |
+      |  table_details              |  alt_text               |
+      |  table_existing             |  no_summary             |
+      |  table_previous             |  no_summary             |
+      |  table_name                 |  full_name              |
+      |  table_email                |  email_address          |
+      |  table_country              |  country_summary        |
+      |  table_post                 |  address_select_summary |
 
   @details
   Scenario: Happy path through details, then back through type
@@ -131,14 +131,14 @@ Feature: I am able to change my answers and correctly navigate through the form
     When I select my address
     Then I am taken to the confirm page of the form
     Then I should see the headers and my information in the summary:
-      |  table_not_received         |  complaint_summary  |
-      |  table_details              |  free_text          |
-      |  table_existing             |  no_summary         |
-      |  table_previous             |  no_summary         |
-      |  table_name                 |  full_name          |
-      |  table_email                |  email_address      |
-      |  table_country              |  country_summary    |
-      |  table_post                 |  address_summary    |
+      |  table_not_received         |  complaint_summary      |
+      |  table_details              |  free_text              |
+      |  table_existing             |  no_summary             |
+      |  table_previous             |  no_summary             |
+      |  table_name                 |  full_name              |
+      |  table_email                |  email_address          |
+      |  table_country              |  country_summary        |
+      |  table_post                 |  address_select_summary |
     When I click change existing from the details page
     Then I am taken to the details_complaint page of the form
     When I click on existing_radio_yes
@@ -167,21 +167,21 @@ Feature: I am able to change my answers and correctly navigate through the form
     When I select my address
     Then I am taken to the confirm page of the form
     Then I should see the headers and my information in the summary:
-      |  table_not_received         |  complaint_summary  |
-      |  table_details              |  free_text          |
-      |  table_existing             |  yes_summary        |
-      |  table_previous             |  no_summary         |
-      |  table_type                 |  marriage_summary   |
-      |  table_person_one           |  full_name          |
-      |  table_person_two           |  first_alt_name     |
-      |  table_how                  |  online_summary     |
-      |  table_online_toggle_text   |  col_number         |
-      |  table_which                |  standard_summary   |
-      |  table_when                 |  date_summary       |
-      |  table_name                 |  full_name          |
-      |  table_email                |  email_address      |
-      |  table_country              |  country_summary    |
-      |  table_post                 |  address_summary    |
+      |  table_not_received         |  complaint_summary      |
+      |  table_details              |  free_text              |
+      |  table_existing             |  yes_summary            |
+      |  table_previous             |  no_summary             |
+      |  table_type                 |  marriage_summary       |
+      |  table_person_one           |  full_name              |
+      |  table_person_two           |  first_alt_name         |
+      |  table_how                  |  online_summary         |
+      |  table_online_toggle_text   |  col_number             |
+      |  table_which                |  standard_summary       |
+      |  table_when                 |  date_summary           |
+      |  table_name                 |  full_name              |
+      |  table_email                |  email_address          |
+      |  table_country              |  country_summary        |
+      |  table_post                 |  address_select_summary |
 
   @about @type
   Scenario: Change
@@ -215,17 +215,17 @@ Feature: I am able to change my answers and correctly navigate through the form
     When I select my address
     Then I am taken to the confirm page of the form
     Then I should see the headers and my information in the summary:
-      |  table_not_received         |  not_received_summary  |
-      |  table_type                 |  birth_summary         |
-      |  table_person_text          |  full_name             |
-      |  table_additional_text      |  free_text             |
-      |  table_additional_radio     |  yes_summary           |
-      |  table_which                |  standard_summary      |
-      |  table_when                 |  date_summary          |
-      |  table_name                 |  full_name             |
-      |  table_email                |  email_address         |
-      |  table_country              |  country_summary       |
-      |  table_post                 |  address_summary       |
+      |  table_not_received         |  not_received_summary   |
+      |  table_type                 |  birth_summary          |
+      |  table_person_text          |  full_name              |
+      |  table_additional_text      |  free_text              |
+      |  table_additional_radio     |  yes_summary            |
+      |  table_which                |  standard_summary       |
+      |  table_when                 |  date_summary           |
+      |  table_name                 |  full_name              |
+      |  table_email                |  email_address          |
+      |  table_country              |  country_summary        |
+      |  table_post                 |  address_select_summary |
     When I click change about from the about page
     Then I am taken to the about page of the form
     When I click complaint and then continue
@@ -243,11 +243,11 @@ Feature: I am able to change my answers and correctly navigate through the form
     When I select my address
     Then I am taken to the confirm page of the form
     Then I should see the headers and my information in the summary:
-      |  table_not_received         |  complaint_summary  |
-      |  table_details              |  free_text          |
-      |  table_existing             |  no_summary         |
-      |  table_previous             |  no_summary         |
-      |  table_name                 |  full_name          |
-      |  table_email                |  email_address      |
-      |  table_country              |  country_summary    |
-      |  table_post                 |  address_summary    |
+      |  table_not_received         |  complaint_summary      |
+      |  table_details              |  free_text              |
+      |  table_existing             |  no_summary             |
+      |  table_previous             |  no_summary             |
+      |  table_name                 |  full_name              |
+      |  table_email                |  email_address          |
+      |  table_country              |  country_summary        |
+      |  table_post                 |  address_select_summary |

--- a/acceptance_tests/features/happy.feature
+++ b/acceptance_tests/features/happy.feature
@@ -33,17 +33,17 @@ Feature: I am able to navigate through the GRO form correctly
     When I select my address
     Then I am taken to the confirm page of the form
     Then I should see the headers and my information in the summary:
-      |  table_not_received         |  not_received_summary  |
-      |  table_type                 |  birth_summary         |
-      |  table_person_text          |  full_name             |
-      |  table_additional_text      |  free_text             |
-      |  table_additional_radio     |  yes_summary           |
-      |  table_which                |  standard_summary      |
-      |  table_when                 |  date_summary          |
-      |  table_name                 |  full_name             |
-      |  table_email                |  email_address         |
-      |  table_country              |  country_summary       |
-      |  table_post                 |  address_summary       |
+      |  table_not_received         |  not_received_summary   |
+      |  table_type                 |  birth_summary          |
+      |  table_person_text          |  full_name              |
+      |  table_additional_text      |  free_text              |
+      |  table_additional_radio     |  yes_summary            |
+      |  table_which                |  standard_summary       |
+      |  table_when                 |  date_summary           |
+      |  table_name                 |  full_name              |
+      |  table_email                |  email_address          |
+      |  table_country              |  country_summary        |
+      |  table_post                 |  address_select_summary |
     When I click Confirm submission
     Then I am taken to the confirmation page
 
@@ -66,14 +66,14 @@ Feature: I am able to navigate through the GRO form correctly
     When I select my address
     Then I am taken to the confirm page of the form
     Then I should see the headers and my information in the summary:
-      |  table_not_received         |  complaint_summary  |
-      |  table_details              |  free_text          |
-      |  table_existing             |  no_summary         |
-      |  table_previous             |  no_summary         |
-      |  table_name                 |  full_name          |
-      |  table_email                |  email_address      |
-      |  table_country              |  country_summary    |
-      |  table_post                 |  address_summary    |
+      |  table_not_received         |  complaint_summary      |
+      |  table_details              |  free_text              |
+      |  table_existing             |  no_summary             |
+      |  table_previous             |  no_summary             |
+      |  table_name                 |  full_name              |
+      |  table_email                |  email_address          |
+      |  table_country              |  country_summary        |
+      |  table_post                 |  address_select_summary |
     When I click Confirm submission
     Then I am taken to the confirmation page
 
@@ -108,20 +108,20 @@ Feature: I am able to navigate through the GRO form correctly
     When I select my address
     Then I am taken to the confirm page of the form
     Then I should see the headers and my information in the summary:
-      |  table_not_received         |  other_summary     |
-      |  table_details              |  free_text         |
-      |  table_existing             |  yes_summary       |
-      |  table_previous             |  yes_summary       |
-      |  table_type                 |  marriage_summary  |
-      |  table_person_one           |  full_name         |
-      |  table_person_two           |  first_alt_name    |
-      |  table_how                  |  online_summary    |
-      |  table_online_toggle_text   |  col_number        |
-      |  table_which                |  standard_summary  |
-      |  table_when                 |  date_summary      |
-      |  table_name                 |  full_name         |
-      |  table_email                |  email_address     |
-      |  table_country              |  country_summary   |
-      |  table_post                 |  address_summary   |
+      |  table_not_received         |  other_summary          |
+      |  table_details              |  free_text              |
+      |  table_existing             |  yes_summary            |
+      |  table_previous             |  yes_summary            |
+      |  table_type                 |  marriage_summary       |
+      |  table_person_one           |  full_name              |
+      |  table_person_two           |  first_alt_name         |
+      |  table_how                  |  online_summary         |
+      |  table_online_toggle_text   |  col_number             |
+      |  table_which                |  standard_summary       |
+      |  table_when                 |  date_summary           |
+      |  table_name                 |  full_name              |
+      |  table_email                |  email_address          |
+      |  table_country              |  country_summary        |
+      |  table_post                 |  address_select_summary |
     When I click Confirm submission
     Then I am taken to the confirmation page

--- a/acceptance_tests/features/postcode.feature
+++ b/acceptance_tests/features/postcode.feature
@@ -34,17 +34,17 @@ Feature: I am able to navigate through the GRO form correctly
     When I select my address
     Then I am taken to the confirm page of the form
     Then I should see the headers and my information in the summary:
-      |  table_not_received         |  not_received_summary  |
-      |  table_type                 |  birth_summary         |
-      |  table_person_text          |  full_name             |
-      |  table_additional_text      |  free_text             |
-      |  table_additional_radio     |  yes_summary           |
-      |  table_which                |  standard_summary      |
-      |  table_when                 |  date_summary          |
-      |  table_name                 |  full_name             |
-      |  table_email                |  email_address         |
-      |  table_country              |  country_summary       |
-      |  table_address              |  address_summary       |
+      |  table_not_received         |  not_received_summary   |
+      |  table_type                 |  birth_summary          |
+      |  table_person_text          |  full_name              |
+      |  table_additional_text      |  free_text              |
+      |  table_additional_radio     |  yes_summary            |
+      |  table_which                |  standard_summary       |
+      |  table_when                 |  date_summary           |
+      |  table_name                 |  full_name              |
+      |  table_email                |  email_address          |
+      |  table_country              |  country_summary        |
+      |  table_address              |  address_select_summary |
     When I click Confirm submission
     Then I am taken to the confirmation page
 

--- a/acceptance_tests/features/support/content.yml
+++ b/acceptance_tests/features/support/content.yml
@@ -91,6 +91,7 @@ date_summary: '10-10-2015'
 country_summary: 'United Kingdom'
 country_summary_not_uk: 'France'
 address_summary: "49 Sydenham Road\nCroydon\nCR0 2EU"
+address_select_summary: "49 Sydenham Road, Croydon, CR0 2EU"
 address_summary_uk: '49 Sydenham Road Croydon'
 address_summary_not_uk: '49 Yellow Brick Road Emerald City'
 address_summary_NI: '49 Yellow Brick Road Emerald City'

--- a/apps/gro/controllers/address.js
+++ b/apps/gro/controllers/address.js
@@ -22,4 +22,14 @@ module.exports = class AddressController extends BaseController {
       postcodeApiMessageKey: isManual ? '' : (req.sessionModel.get('postcodeApiMeta') || {}).messageKey
     });
   }
+
+  saveValues(req, res, callback) {
+    super.saveValues(req, res, err => {
+      if (err) {
+        return callback(err);
+      }
+      req.sessionModel.unset('address-lookup');
+      return callback();
+    });
+  }
 };

--- a/apps/gro/controllers/confirm.js
+++ b/apps/gro/controllers/confirm.js
@@ -1,0 +1,24 @@
+'use strict';
+
+const BaseConfirmController = require('hof-controllers').confirm;
+
+module.exports = class ConfirmController extends BaseConfirmController {
+  get(req, res, callback) {
+    this.removeDuplicateAddress(req);
+    return super.get(req, res, callback);
+  }
+
+  post(req, res, callback) {
+    this.removeDuplicateAddress(req);
+    return super.post(req, res, callback);
+  }
+
+  removeDuplicateAddress(req) {
+    const lookup = req.sessionModel.get('address-lookup');
+    if (lookup) {
+      this.options.fieldsConfig['address-textarea'].includeInSummary = false;
+    } else {
+      this.options.fieldsConfig['address-textarea'].includeInSummary = true;
+    }
+  }
+};

--- a/apps/gro/fields.js
+++ b/apps/gro/fields.js
@@ -141,7 +141,8 @@ module.exports = {
   'postcode-code': {
     mixin: 'input-text-code',
     validate: ['required', 'postcode'],
-    formatter: 'uppercase'
+    formatter: 'uppercase',
+    includeInSummary: false
   },
   'type-radio': {
     legend: {

--- a/apps/gro/index.js
+++ b/apps/gro/index.js
@@ -205,8 +205,8 @@ module.exports = {
     },
     '/confirm': {
       next: '/confirmation',
-      controller: controllers.confirm,
-      fieldsConfig: require('./fields'),
+      controller: require('./controllers/confirm'),
+      fieldsConfig: _.cloneDeep(require('./fields')),
       emailConfig: require('../../config').email,
       customerEmailField: 'email-text',
       locals: {

--- a/apps/gro/translations/src/en/fields.json
+++ b/apps/gro/translations/src/en/fields.json
@@ -198,7 +198,8 @@
     "label": "Postcode"
   },
   "address-lookup": {
-    "label": "Select your address"
+    "label": "Select your address",
+    "summary": "Address"
   },
   "address-textarea": {
     "summary": "Address",

--- a/test/unit/apps/gro/controllers/confirm.js
+++ b/test/unit/apps/gro/controllers/confirm.js
@@ -1,0 +1,108 @@
+'use strict';
+
+const proxyquire = require('proxyquire');
+
+describe('Confirm Controller', () => {
+  const req = {};
+  const res = {};
+  const cb = sinon.stub();
+  let Controller;
+  let controller;
+  class StubController {}
+
+  beforeEach(() => {
+    StubController.prototype.get = sinon.stub();
+    StubController.prototype.post = sinon.stub();
+    Controller = proxyquire('../../../../../apps/gro/controllers/confirm', {
+      'hof-controllers': {
+        confirm: StubController
+      }
+    });
+    controller = new Controller();
+  });
+
+  it('extends from the base confirm controller', () => {
+    controller.should.be.an.instanceOf(StubController);
+  });
+
+  it('has a get method', () => {
+    controller.should.have.property('get');
+  });
+
+  it('has a post method', () => {
+    controller.should.have.property('post');
+  });
+
+  it('has a removeDuplicateAddress method', () => {
+    controller.should.have.property('removeDuplicateAddress');
+  });
+
+  describe('get', () => {
+    beforeEach(() => {
+      sinon.stub(Controller.prototype, 'removeDuplicateAddress');
+    });
+
+    afterEach(() => {
+      Controller.prototype.removeDuplicateAddress.restore();
+    });
+
+    it('calls removeDuplicateAddress passing req', () => {
+      controller.get(req, res, cb);
+      Controller.prototype.removeDuplicateAddress.should.have.been.calledOnce
+        .and.calledWithExactly(req);
+    });
+
+    it('calls super', () => {
+      controller.get(req, res, cb);
+      StubController.prototype.get.should.have.been.calledOnce
+        .and.calledWithExactly(req, res, cb);
+    });
+  });
+
+  describe('post', () => {
+    beforeEach(() => {
+      sinon.stub(Controller.prototype, 'removeDuplicateAddress');
+    });
+
+    afterEach(() => {
+      Controller.prototype.removeDuplicateAddress.restore();
+    });
+
+    it('calls removeDuplicateAddress passing req', () => {
+      controller.post(req, res, cb);
+      Controller.prototype.removeDuplicateAddress.should.have.been.calledOnce
+        .and.calledWithExactly(req);
+    });
+
+    it('calls super', () => {
+      controller.post(req, res, cb);
+      StubController.prototype.post.should.have.been.calledOnce
+        .and.calledWithExactly(req, res, cb);
+    });
+  });
+
+  describe('removeDuplicateAddress', () => {
+    beforeEach(() => {
+      req.sessionModel = {
+        get: sinon.stub()
+      };
+      controller.options = {
+        fieldsConfig: {
+          'address-textarea': {}
+        }
+      };
+    });
+
+    it('sets includeInSummary to false for address-textarea if address-lookup set', () => {
+      req.sessionModel.get.returns(true);
+      controller.removeDuplicateAddress(req);
+      controller.options.fieldsConfig['address-textarea'].includeInSummary.should.be.false;
+    });
+
+    it('sets includeInSummary to true for address-textarea if address-lookup not set', () => {
+      req.sessionModel.get.returns(false);
+      controller.removeDuplicateAddress(req);
+      controller.options.fieldsConfig['address-textarea'].includeInSummary.should.be.true;
+    });
+  });
+});


### PR DESCRIPTION
* added confirm controller
* if address-lookup set then don't show address-textarea
* if manual address set, unset address-lookup
* updated tests