### PR TITLE
Fix path for common translations

### DIFF
--- a/package.json
+++ b/package.json
@@ -27,7 +27,7 @@
     "cover": "istanbul cover _mocha && istanbul check-coverage",
     "sass": "npm-sass ./assets/scss/app.scss > ./public/css/app.css",
     "create:public": "mkdir -p ./public/js ./public/css ./public/images",
-    "hof-transpile": "hof-transpiler ./apps/**/translations/src -w --shared ./node_modules/hof-template-partials/translations",
+    "hof-transpile": "hof-transpiler ./apps/**/translations/src --shared ./node_modules/hof-template-partials/translations/src",
     "prepareapp": "npm run create:public; npm run sass; npm run browserify; npm run copy:images; npm run hof-transpile",
     "postinstall": "bash -c 'if [[ ${NODE_ENV} != production ]]; then npm run prepareapp; fi;'"
   },


### PR DESCRIPTION
The path needs to have `src/` on the end or it detects js files in the parent directory too.