### PR TITLE
Push version of deprecate back to 1.0.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1763,9 +1763,9 @@
       "integrity": "sha1-m81S4UwJd2PnSbJ0xDRu0uVgtak="
     },
     "deprecate": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/deprecate/-/deprecate-1.1.0.tgz",
-      "integrity": "sha512-b5dDNQYdy2vW9WXUD8+RQlfoxvqztLLhDE+T7Gd37I5E8My7nJkKu6FmhdDeRWJ8B+yjZKuwjCta8pgi8kgSqA=="
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/deprecate/-/deprecate-1.0.0.tgz",
+      "integrity": "sha1-ZhSQ7SQokWpsiIPYg05WRvTkpKg="
     },
     "deps-sort": {
       "version": "2.0.0",

--- a/package.json
+++ b/package.json
@@ -34,6 +34,7 @@
   "author": "HomeOffice",
   "dependencies": {
     "browserify": "^12.0.1",
+    "deprecate": "^1.0.0",
     "hof-bootstrap": "^9.0.0",
     "hof-controllers": "^4.0.1",
     "hof-frontend-toolkit": "^1.0.1",


### PR DESCRIPTION
The package shipped a breaking change in 1.1.0, which causes an error at start-up time. Force this project to use 1.0.0 to work around.