### PR TITLE
SD-863 fix Gro io exception: increase the memory requests

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,3 +47,4 @@ This project is licensed under the GPLv2 License - see the [LICENSE.md](LICENSE.
 
 The General Registrars Office uses BrowserStack for mobile and desktop testing https://www.browserstack.com/
 
+


### PR DESCRIPTION
What?

This is to fix a bug EIO: i/o error, scandir 'app/node_modules/ hof-emailer/views in the dev environment. The fix is to provide more memory in our environments

Why?

It's unclear what the issue is
memory certainly seems like a safe bet then. 10mb isn’t even enough to run the bare process, so you’re inviting errors if you try to get away with that. Recommend 128mb from other
teams
You should request enough memory for your pod to run. That's the only memory which will be reserved for your pod - the cluster may or may not give you any more memory up to your
limit.
(for example, if you requested 32MB memory, you might be scheduled on a node with only 32MB left, in which case your pod wouldn't be able to use any more than that)
ASL project has 32mb for back-end data API services 128mb for UIs.
The UI services tend to keep a lot of in-memory caches, so use more memory.
How?

in the kube file

Testing?

Can't test it until will deploy it