### PR TITLE
Update Node from v14 to v18

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -41,7 +41,7 @@ unit_tests: &unit_tests
 
 sonar_scanner: &sonar_scanner
   pull: if-not-exists
-  image: quay.io/ukhomeofficedigital/sonar-scanner-node:549b75f593f28da1c4a0a6f79877ec69d3b21037
+  image: quay.io/ukhomeofficedigital/sonar-scanner-nodejs:latest
   commands:
     - sonar-scanner -Dproject.settings=./sonar-project.properties
 

--- a/.drone.yml
+++ b/.drone.yml
@@ -25,7 +25,7 @@ trigger:
 
 linting: &linting
   pull: if-not-exists
-  image: node:14
+  image: node:18
   environment:
     NOTIFY_KEY: USE_MOCK
   commands:
@@ -33,7 +33,7 @@ linting: &linting
 
 unit_tests: &unit_tests
   pull: if-not-exists
-  image: node:14
+  image: node:18
   environment:
     NOTIFY_KEY: USE_MOCK
   commands:
@@ -47,7 +47,7 @@ sonar_scanner: &sonar_scanner
 
 integration_tests: &integration_tests
   pull: if-not-exists
-  image: node:14
+  image: node:18
   environment:
     NOTIFY_KEY: USE_MOCK
 
@@ -77,7 +77,7 @@ steps:
 
   - name: setup_deploy
     pull: if-not-exists
-    image: node:14
+    image: node:18
     environment:
       NOTIFY_KEY: USE_MOCK
     commands:
@@ -165,7 +165,7 @@ steps:
 
   - name: setup_branch
     pull: if-not-exists
-    image: node:14
+    image: node:18
     environment:
       NOTIFY_KEY: USE_MOCK
     commands:
@@ -229,7 +229,7 @@ steps:
   # Snyk & Anchore security scans which run after branch deployment to prevent blocking of PR UAT tests
   - name: snyk_scan
     pull: if-not-exists
-    image: node:14
+    image: node:18
     environment:
       SNYK_TOKEN:
         from_secret: snyk_token
@@ -415,7 +415,7 @@ steps:
 
   - name: cron_snyk_scan
     pull: if-not-exists
-    image: node:14
+    image: node:18
     environment:
       SNYK_TOKEN:
         from_secret: snyk_token

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM node:14-alpine@sha256:5c33bc6f021453ae2e393e6e20650a4df0a4737b1882d389f17069dc1933fdc5
+FROM node:18-alpine@sha256:19eaf41f3b8c2ac2f609ac8103f9246a6a6d46716cdbe49103fdb116e55ff0cc
 
 USER root
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -4,7 +4,7 @@ USER root
 
 # Update packages as a result of Anchore security vulnerability checks
 RUN apk update && \
-    apk add --upgrade gnutls binutils nodejs npm apk-tools libjpeg-turbo libcurl libx11 libxml2 \
+    apk add --upgrade gnutls binutils nodejs npm apk-tools libjpeg-turbo libcurl libx11 libxml2
 
 
 # Setup nodejs group & nodejs user

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,10 +1,11 @@
-FROM node:18-alpine@sha256:19eaf41f3b8c2ac2f609ac8103f9246a6a6d46716cdbe49103fdb116e55ff0cc
+FROM node:18-alpine@sha256:2322b1bb3917b313f2e9308395aa5c39d51b91cc92a5d4d5be6d0451fcfb4d24
 
 USER root
 
 # Update packages as a result of Anchore security vulnerability checks
 RUN apk update && \
-    apk add --upgrade gnutls binutils nodejs nodejs-npm apk-tools libjpeg-turbo libcurl libx11 libxml2
+    apk add --upgrade gnutls binutils nodejs npm apk-tools libjpeg-turbo libcurl libx11 libxml2 \
+
 
 # Setup nodejs group & nodejs user
 RUN addgroup --system nodejs --gid 998 && \

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -24,7 +24,7 @@ services:
     image: redis
 
   nginx-proxy:
-    image: quay.io/ukhomeofficedigital/nginx-proxy:v1.2.3
+    image: quay.io/ukhomeofficedigital/nginx-proxy:latest
     environment:
       - PROXY_SERVICE_HOST=app
       - PROXY_SERVICE_PORT=8080

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -8,6 +8,7 @@ services:
       - EMAIL_HOST=maildev
       - EMAIL_PORT=25
       - CASEWORKER_EMAIL=caseworker@gov.uk.test
+      - NOTIFY_KEY=hof_test-89548f6c-39cd-4acb-851c-1f4ffa2e479b-28426e56-443a-4ba4-98ed-fb576e717ed9
       - REDIS_HOST=redis
       - REDIS_PORT=6379
       - SESSION_SECRET=adsasdasd

--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "description": "The General Register Office DSP form",
   "license": "GPL-2.0",
   "engines": {
-    "node": ">=18.12.0"
+    "node": ">=18.12.1"
   },
   "repository": {
     "type": "git",
@@ -29,7 +29,7 @@
   "dependencies": {
     "browserify": "^17.0.0",
     "deprecate": "^1.0.0",
-    "hof": "^20.2.2",
+    "hof": "^20.1.21",
     "homeoffice-countries": "^0.1.0",
     "jquery": "^3.6.0",
     "lodash": "^4.17.21",

--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "description": "The General Register Office DSP form",
   "license": "GPL-2.0",
   "engines": {
-    "node": ">=14.15.0"
+    "node": ">=18.15.0"
   },
   "repository": {
     "type": "git",
@@ -29,7 +29,7 @@
   "dependencies": {
     "browserify": "^17.0.0",
     "deprecate": "^1.0.0",
-    "hof": "^20.1.21",
+    "hof": "^20.2.2",
     "homeoffice-countries": "^0.1.0",
     "jquery": "^3.6.0",
     "lodash": "^4.17.21",

--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "description": "The General Register Office DSP form",
   "license": "GPL-2.0",
   "engines": {
-    "node": ">=18.15.0"
+    "node": ">=18.12.0"
   },
   "repository": {
     "type": "git",

--- a/yarn.lock
+++ b/yarn.lock
@@ -3016,10 +3016,10 @@ hmac-drbg@^1.0.1:
     minimalistic-assert "^1.0.0"
     minimalistic-crypto-utils "^1.0.1"
 
-hof@^20.1.21:
-  version "20.1.21"
-  resolved "https://registry.yarnpkg.com/hof/-/hof-20.1.21.tgz#682eaf167fb4df022f64de3ede941727543c0d85"
-  integrity sha512-3jhssUN2eWfK9NOUFon4WiGu6SE49hoO1rSWOKVbezPQgyQHEvxGyjUQefCDXTs/MUN9F311MLvTVQUPvdg/7A==
+hof@^20.2.2:
+  version "20.2.2"
+  resolved "https://registry.yarnpkg.com/hof/-/hof-20.2.2.tgz#268feca3173010b432289d87bd8adeec89467f1d"
+  integrity sha512-EO4/f/Y7pO7IbxuF//vcR2dIKeay6rbZiuM+0PNj3kkxq0X6uxd17oKam7SedRXaStnbhWEjXbzFCl0S2OONvA==
   dependencies:
     aliasify "^2.1.0"
     bluebird "^3.7.2"

--- a/yarn.lock
+++ b/yarn.lock
@@ -3016,7 +3016,7 @@ hmac-drbg@^1.0.1:
     minimalistic-assert "^1.0.0"
     minimalistic-crypto-utils "^1.0.1"
 
-hof@^20.2.2:
+hof@^20.1.21:
   version "20.2.2"
   resolved "https://registry.yarnpkg.com/hof/-/hof-20.2.2.tgz#268feca3173010b432289d87bd8adeec89467f1d"
   integrity sha512-EO4/f/Y7pO7IbxuF//vcR2dIKeay6rbZiuM+0PNj3kkxq0X6uxd17oKam7SedRXaStnbhWEjXbzFCl0S2OONvA==


### PR DESCRIPTION
## What?
Update project to Node version 18.15.0. see jira ticket #GRO-121.
https://collaboration.homeoffice.gov.uk/jira/browse/GRO-121
## Why?
Part of Epic to upgrade all HOF services to Node v18. see jira ticket #HOFF-312
https://collaboration.homeoffice.gov.uk/jira/browse/HOFF-312
## How?
- Updated node engine inside package.json from 14.15.0 to 18.15.0
- Updated main docker image to node:18-alpine
- Changed all references to node:14 in drone.yml to node:18
## Testing?
- All unit tests + acceptance tests pass
- Requires testing from QAT team
## Screenshots (optional)
## Anything Else?