### PR TITLE
Release branch v2.5.0 

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -41,7 +41,7 @@ unit_tests: &unit_tests
 
 sonar_scanner: &sonar_scanner
   pull: if-not-exists
-  image: quay.io/ukhomeofficedigital/sonar-scanner-node:549b75f593f28da1c4a0a6f79877ec69d3b21037
+  image: quay.io/ukhomeofficedigital/sonar-scanner-nodejs:latest
   commands:
     - sonar-scanner -Dproject.settings=./sonar-project.properties
 

--- a/.drone.yml
+++ b/.drone.yml
@@ -25,7 +25,7 @@ trigger:
 
 linting: &linting
   pull: if-not-exists
-  image: node:14
+  image: node:18
   environment:
     NOTIFY_KEY: USE_MOCK
   commands:
@@ -33,7 +33,7 @@ linting: &linting
 
 unit_tests: &unit_tests
   pull: if-not-exists
-  image: node:14
+  image: node:18
   environment:
     NOTIFY_KEY: USE_MOCK
   commands:
@@ -47,7 +47,7 @@ sonar_scanner: &sonar_scanner
 
 integration_tests: &integration_tests
   pull: if-not-exists
-  image: node:14
+  image: node:18
   environment:
     NOTIFY_KEY: USE_MOCK
 
@@ -77,7 +77,7 @@ steps:
 
   - name: setup_deploy
     pull: if-not-exists
-    image: node:14
+    image: node:18
     environment:
       NOTIFY_KEY: USE_MOCK
     commands:
@@ -165,7 +165,7 @@ steps:
 
   - name: setup_branch
     pull: if-not-exists
-    image: node:14
+    image: node:18
     environment:
       NOTIFY_KEY: USE_MOCK
     commands:
@@ -229,7 +229,7 @@ steps:
   # Snyk & Anchore security scans which run after branch deployment to prevent blocking of PR UAT tests
   - name: snyk_scan
     pull: if-not-exists
-    image: node:14
+    image: node:18
     environment:
       SNYK_TOKEN:
         from_secret: snyk_token
@@ -415,7 +415,7 @@ steps:
 
   - name: cron_snyk_scan
     pull: if-not-exists
-    image: node:14
+    image: node:18
     environment:
       SNYK_TOKEN:
         from_secret: snyk_token

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM node:14-alpine@sha256:5c33bc6f021453ae2e393e6e20650a4df0a4737b1882d389f17069dc1933fdc5
+FROM node:18-alpine@sha256:19eaf41f3b8c2ac2f609ac8103f9246a6a6d46716cdbe49103fdb116e55ff0cc
 
 USER root
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -4,7 +4,7 @@ USER root
 
 # Update packages as a result of Anchore security vulnerability checks
 RUN apk update && \
-    apk add --upgrade gnutls binutils nodejs npm apk-tools libjpeg-turbo libcurl libx11 libxml2 \
+    apk add --upgrade gnutls binutils nodejs npm apk-tools libjpeg-turbo libcurl libx11 libxml2
 
 
 # Setup nodejs group & nodejs user

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,10 +1,11 @@
-FROM node:18-alpine@sha256:19eaf41f3b8c2ac2f609ac8103f9246a6a6d46716cdbe49103fdb116e55ff0cc
+FROM node:18-alpine@sha256:2322b1bb3917b313f2e9308395aa5c39d51b91cc92a5d4d5be6d0451fcfb4d24
 
 USER root
 
 # Update packages as a result of Anchore security vulnerability checks
 RUN apk update && \
-    apk add --upgrade gnutls binutils nodejs nodejs-npm apk-tools libjpeg-turbo libcurl libx11 libxml2
+    apk add --upgrade gnutls binutils nodejs npm apk-tools libjpeg-turbo libcurl libx11 libxml2 \
+
 
 # Setup nodejs group & nodejs user
 RUN addgroup --system nodejs --gid 998 && \

--- a/README.md
+++ b/README.md
@@ -60,3 +60,4 @@ This project is licensed under the GPLv2 License - see the [LICENSE.md](LICENSE.
 
 The General Register Office uses BrowserStack for mobile and desktop testing https://www.browserstack.com/
 
+

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -24,7 +24,7 @@ services:
     image: redis
 
   nginx-proxy:
-    image: quay.io/ukhomeofficedigital/nginx-proxy:v1.2.3
+    image: quay.io/ukhomeofficedigital/nginx-proxy:latest
     environment:
       - PROXY_SERVICE_HOST=app
       - PROXY_SERVICE_PORT=8080

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -8,6 +8,7 @@ services:
       - EMAIL_HOST=maildev
       - EMAIL_PORT=25
       - CASEWORKER_EMAIL=caseworker@gov.uk.test
+      - NOTIFY_KEY=hof_test-89548f6c-39cd-4acb-851c-1f4ffa2e479b-28426e56-443a-4ba4-98ed-fb576e717ed9
       - REDIS_HOST=redis
       - REDIS_PORT=6379
       - SESSION_SECRET=adsasdasd

--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "description": "The General Register Office DSP form",
   "license": "GPL-2.0",
   "engines": {
-    "node": ">=18.12.0"
+    "node": ">=18.12.1"
   },
   "repository": {
     "type": "git",
@@ -29,7 +29,7 @@
   "dependencies": {
     "browserify": "^17.0.0",
     "deprecate": "^1.0.0",
-    "hof": "^20.2.2",
+    "hof": "^20.1.21",
     "homeoffice-countries": "^0.1.0",
     "jquery": "^3.6.0",
     "lodash": "^4.17.21",

--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "description": "The General Register Office DSP form",
   "license": "GPL-2.0",
   "engines": {
-    "node": ">=14.15.0"
+    "node": ">=18.15.0"
   },
   "repository": {
     "type": "git",
@@ -29,7 +29,7 @@
   "dependencies": {
     "browserify": "^17.0.0",
     "deprecate": "^1.0.0",
-    "hof": "^20.1.21",
+    "hof": "^20.2.2",
     "homeoffice-countries": "^0.1.0",
     "jquery": "^3.6.0",
     "lodash": "^4.17.21",

--- a/package.json
+++ b/package.json
@@ -29,7 +29,7 @@
   "dependencies": {
     "browserify": "^17.0.0",
     "deprecate": "^1.0.0",
-    "hof": "^20.1.21",
+    "hof": "^20.2.10",
     "homeoffice-countries": "^0.1.0",
     "jquery": "^3.6.0",
     "lodash": "^4.17.21",

--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "description": "The General Register Office DSP form",
   "license": "GPL-2.0",
   "engines": {
-    "node": ">=18.15.0"
+    "node": ">=18.12.0"
   },
   "repository": {
     "type": "git",

--- a/server.js
+++ b/server.js
@@ -9,7 +9,19 @@ let settings = require('./hof.settings');
 
 settings = Object.assign({}, settings, {
   behaviours: settings.behaviours.map(require),
-  routes: settings.routes.map(require)
+  routes: settings.routes.map(require),
+  csp: {
+    imgSrc: [
+      'www.google-analytics.com',
+      'ssl.gstatic.com',
+      'www.google.co.uk/ads/ga-audiences'
+    ],
+    connectSrc: [
+      'https://www.google-analytics.com',
+      'https://region1.google-analytics.com',
+      'https://region1.analytics.google.com'
+    ]
+  }
 });
 
 if (config.env === 'ci') {

--- a/yarn.lock
+++ b/yarn.lock
@@ -3016,10 +3016,10 @@ hmac-drbg@^1.0.1:
     minimalistic-assert "^1.0.0"
     minimalistic-crypto-utils "^1.0.1"
 
-hof@^20.1.21:
-  version "20.1.21"
-  resolved "https://registry.yarnpkg.com/hof/-/hof-20.1.21.tgz#682eaf167fb4df022f64de3ede941727543c0d85"
-  integrity sha512-3jhssUN2eWfK9NOUFon4WiGu6SE49hoO1rSWOKVbezPQgyQHEvxGyjUQefCDXTs/MUN9F311MLvTVQUPvdg/7A==
+hof@^20.2.2:
+  version "20.2.2"
+  resolved "https://registry.yarnpkg.com/hof/-/hof-20.2.2.tgz#268feca3173010b432289d87bd8adeec89467f1d"
+  integrity sha512-EO4/f/Y7pO7IbxuF//vcR2dIKeay6rbZiuM+0PNj3kkxq0X6uxd17oKam7SedRXaStnbhWEjXbzFCl0S2OONvA==
   dependencies:
     aliasify "^2.1.0"
     bluebird "^3.7.2"

--- a/yarn.lock
+++ b/yarn.lock
@@ -1621,7 +1621,7 @@ crypto-browserify@^3.0.0:
     randombytes "^2.0.0"
     randomfill "^1.0.3"
 
-csrf@^3.0.2:
+csrf@^3.1.0:
   version "3.1.0"
   resolved "https://registry.yarnpkg.com/csrf/-/csrf-3.1.0.tgz#ec75e9656d004d674b8ef5ba47b41fbfd6cb9c30"
   integrity sha512-uTqEnCvWRk042asU6JtapDTcJeeailFy4ydOQS28bj1hcLnYRiqi8SsD2jS412AY1I/4qdOwWZun774iqywf9w==
@@ -3016,10 +3016,10 @@ hmac-drbg@^1.0.1:
     minimalistic-assert "^1.0.0"
     minimalistic-crypto-utils "^1.0.1"
 
-hof@^20.1.21:
-  version "20.2.2"
-  resolved "https://registry.yarnpkg.com/hof/-/hof-20.2.2.tgz#268feca3173010b432289d87bd8adeec89467f1d"
-  integrity sha512-EO4/f/Y7pO7IbxuF//vcR2dIKeay6rbZiuM+0PNj3kkxq0X6uxd17oKam7SedRXaStnbhWEjXbzFCl0S2OONvA==
+hof@^20.2.10:
+  version "20.2.10"
+  resolved "https://registry.yarnpkg.com/hof/-/hof-20.2.10.tgz#11b4be553517d79eaa730d7aaa238607b4137964"
+  integrity sha512-tp0quZ8i3JPawSwmbXiwFpMpS9Sc/f9KgXL1zgofSzG+guvJvxmurfRydMsgceawN2W6npk5QT2zLU6Aq8YQvQ==
   dependencies:
     aliasify "^2.1.0"
     bluebird "^3.7.2"
@@ -3031,7 +3031,7 @@ hof@^20.1.21:
     connect-redis "^5.2.0"
     cookie-parser "^1.4.6"
     cp "^0.2.0"
-    csrf "^3.0.2"
+    csrf "^3.1.0"
     debug "^4.3.1"
     deprecate "^1.0.0"
     dotenv "^4.0.0"
@@ -3060,9 +3060,9 @@ hof@^20.1.21:
     mixwith "^0.1.1"
     moment "^2.29.4"
     morgan "^1.10.0"
-    mustache "^2.3.0"
+    mustache "^4.2.0"
     nodemailer "^6.6.3"
-    nodemailer-ses-transport "^1.5.0"
+    nodemailer-ses-transport "^1.5.1"
     nodemailer-smtp-transport "^2.7.4"
     nodemailer-stub-transport "^1.1.0"
     notifications-node-client "^6.0.0"
@@ -3073,7 +3073,7 @@ hof@^20.1.21:
     sass "^1.56.2"
     serve-static "^1.14.1"
     uglify-js "^3.14.3"
-    underscore "^1.12.1"
+    underscore "^1.13.6"
     urijs "^1.19.11"
     uuid "^8.3.2"
     winston "^3.7.2"
@@ -4126,10 +4126,10 @@ ms@2.1.3, ms@^2.1.1:
   resolved "https://registry.yarnpkg.com/ms/-/ms-2.1.3.tgz#574c8138ce1d2b5861f0b44579dbadd60c6615b2"
   integrity sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==
 
-mustache@^2.3.0:
-  version "2.3.2"
-  resolved "https://registry.yarnpkg.com/mustache/-/mustache-2.3.2.tgz#a6d4d9c3f91d13359ab889a812954f9230a3d0c5"
-  integrity sha512-KpMNwdQsYz3O/SBS1qJ/o3sqUJ5wSb8gb0pul8CO0S56b9Y2ALm8zCfsjPXsqGFfoNBkDwZuZIAjhsZI03gYVQ==
+mustache@^4.2.0:
+  version "4.2.0"
+  resolved "https://registry.yarnpkg.com/mustache/-/mustache-4.2.0.tgz#e5892324d60a12ec9c2a73359edca52972bf6f64"
+  integrity sha512-71ippSywq5Yb7/tVYyGbkBggbU8H3u5Rz56fH60jGFgr8uHwxs+aSKeqmluIVzM0m0kB7xQjKS6qPfd0b2ZoqQ==
 
 mz@^2.7.0:
   version "2.7.0"
@@ -4212,7 +4212,7 @@ nodemailer-fetch@1.6.0:
   resolved "https://registry.yarnpkg.com/nodemailer-fetch/-/nodemailer-fetch-1.6.0.tgz#79c4908a1c0f5f375b73fe888da9828f6dc963a4"
   integrity sha512-P7S5CEVGAmDrrpn351aXOLYs1R/7fD5NamfMCHyi6WIkbjS2eeZUB/TkuvpOQr0bvRZicVqo59+8wbhR3yrJbQ==
 
-nodemailer-ses-transport@^1.5.0:
+nodemailer-ses-transport@^1.5.1:
   version "1.5.1"
   resolved "https://registry.yarnpkg.com/nodemailer-ses-transport/-/nodemailer-ses-transport-1.5.1.tgz#dc0598c1bf53e8652e632e8f31692ce022d7dea9"
   integrity sha512-JwL93Lc7KEWbH4a9Ehm6XCJgNhf6QNleSDkIsCvEyViKzqvYsf+8rF2PG8OzI1xDyxvtgsaWAmJWMqABOZmnWg==
@@ -5801,7 +5801,7 @@ undeclared-identifiers@^1.1.2:
     simple-concat "^1.0.0"
     xtend "^4.0.1"
 
-underscore@^1.12.1, underscore@^1.7.0, underscore@^1.8.2, underscore@~1.7.0:
+underscore@^1.12.1, underscore@^1.13.6, underscore@^1.7.0, underscore@^1.8.2, underscore@~1.7.0:
   version "1.13.6"
   resolved "https://registry.yarnpkg.com/underscore/-/underscore-1.13.6.tgz#04786a1f589dc6c09f761fc5f45b89e935136441"
   integrity sha512-+A5Sja4HP1M08MaXya7p5LvjuM7K6q/2EaC0+iovj/wOcMsTzMvDFbasi/oSapiwOlt252IqsKqPjCl7huKS0A==

--- a/yarn.lock
+++ b/yarn.lock
@@ -3016,7 +3016,7 @@ hmac-drbg@^1.0.1:
     minimalistic-assert "^1.0.0"
     minimalistic-crypto-utils "^1.0.1"
 
-hof@^20.2.2:
+hof@^20.1.21:
   version "20.2.2"
   resolved "https://registry.yarnpkg.com/hof/-/hof-20.2.2.tgz#268feca3173010b432289d87bd8adeec89467f1d"
   integrity sha512-EO4/f/Y7pO7IbxuF//vcR2dIKeay6rbZiuM+0PNj3kkxq0X6uxd17oKam7SedRXaStnbhWEjXbzFCl0S2OONvA==


### PR DESCRIPTION
## Release Branch

- for v2.5.0

## Contains the following tickets

- GRO-121: Node 18 upgrade
- GRO-111: GA4 migration with new CSP rules
- GRO-143: Update HOF framework to v20.2.10

