### PR TITLE
GRO-153: test GA on latest hof version

### DIFF
--- a/package.json
+++ b/package.json
@@ -29,7 +29,7 @@
   "dependencies": {
     "browserify": "^17.0.0",
     "deprecate": "^1.0.0",
-    "hof": "^20.2.10",
+    "hof": "~20.2.28",
     "homeoffice-countries": "^0.1.0",
     "jquery": "^3.6.0",
     "lodash": "^4.17.21",

--- a/server.js
+++ b/server.js
@@ -11,6 +11,13 @@ settings = Object.assign({}, settings, {
   behaviours: settings.behaviours.map(require),
   routes: settings.routes.map(require),
   csp: {
+    fontSrc: [
+      'https://fonts.googleapis.com/'
+    ],
+    scriptSrc: [
+      'https://tagmanager.google.com/',
+      'https://www.googletagmanager.com/'
+    ],
     imgSrc: [
       'www.google-analytics.com',
       'ssl.gstatic.com',

--- a/yarn.lock
+++ b/yarn.lock
@@ -3016,10 +3016,10 @@ hmac-drbg@^1.0.1:
     minimalistic-assert "^1.0.0"
     minimalistic-crypto-utils "^1.0.1"
 
-hof@^20.2.10:
-  version "20.2.10"
-  resolved "https://registry.yarnpkg.com/hof/-/hof-20.2.10.tgz#11b4be553517d79eaa730d7aaa238607b4137964"
-  integrity sha512-tp0quZ8i3JPawSwmbXiwFpMpS9Sc/f9KgXL1zgofSzG+guvJvxmurfRydMsgceawN2W6npk5QT2zLU6Aq8YQvQ==
+hof@~20.2.28:
+  version "20.2.28"
+  resolved "https://registry.yarnpkg.com/hof/-/hof-20.2.28.tgz#349b12321b67bcc337fb09c3ea79c863ce5b440c"
+  integrity sha512-K1abZdRen3snVsjTronpOTEPz+9cYq5B3u2TBtoFmPZ3qF8O0vpvGAdbPkp04qJvP74IeN/l+/WOeHTfrau4Aw==
   dependencies:
     aliasify "^2.1.0"
     bluebird "^3.7.2"


### PR DESCRIPTION
## What?
Upgrade hof from v20.2.1 to v20.2.28 (gtm-beta)

## Why?
Test that this hof upgrade (intended for ETA) works fine in other forms with no issues

## How?

## Testing?

