### PR TITLE
GRO-215: Update Accessibility Statement

### DIFF
--- a/apps/gro/views/accessibility.html
+++ b/apps/gro/views/accessibility.html
@@ -21,25 +21,16 @@
     </ul>
     <p class="govuk-body">{{#t}}accessibility.intro-p3-pre-link{{/t}} <a class="govuk-link" rel="noreferrer noopener" target="_blank" href="https://mcmw.abilitynet.org.uk/">{{#t}}accessibility.intro-p3-link{{/t}}</a> {{#t}}accessibility.intro-p3-post-link{{/t}}</p>
     <h2 class="govuk-heading-m">Reporting accessibility problems with this service</h2>
-    <p class="govuk-body">We’re always looking to improve the accessibility of our services. If you find any problems not listed on this page or think we’re not meeting accessibility requirements, email:<a href="mailto:{{#t}}accessibility.contact-email-accessibility{{/t}}">{{#t}}accessibility.contact-email-accessibility{{/t}}</a></p>
+    <p class="govuk-body">We’re always looking to improve the accessibility of our services. If you find any problems not listed on this page or think we’re not meeting accessibility requirements, email: <a href="mailto:{{#t}}accessibility.contact-email-accessibility{{/t}}">{{#t}}accessibility.contact-email-accessibility{{/t}}</a></p>
     <h2 class="govuk-heading-m">{{#t}}accessibility.enforcement-header{{/t}}</h2>
     <p class="govuk-body">{{#t}}accessibility.enforcement-p1-pre-link{{/t}} <a class="govuk-link" rel="noreferrer noopener" target="_blank" href ="https://www.equalityadvisoryservice.com/">{{#t}}accessibility.enforcement-p1-link{{/t}}</a></p>
     <p class="govuk-body">If you are in Northern Ireland and are not happy with how we respond to your complaint you can contact the <a class="govuk-link" rel="noreferrer noopener" target="_blank" href="https://www.equalityni.org/Home">Equalities Commission for Northern Ireland</a> who are responsible for enforcing the Public Sector Bodies (Websites and Mobile Applications) (No. 2) Accessibility Regulations 2018 (the ‘accessibility regulations’) in Northern Ireland.</p>
     <h2 class="govuk-heading-m">{{#t}}accessibility.technical-info-header{{/t}}</h2>
     <p class="govuk-body">The Home Office is committed to making its online services accessible, in accordance with the Public Sector Bodies (Websites and Mobile Applications) (No. 2) Accessibility Regulations 2018.</p>
     <h2 class="govuk-heading-m">{{#t}}accessibility.compliance-header{{/t}}</h2>
-    <p class="govuk-body">This service is partially compliant with the <a class="govuk-link" rel="noreferrer noopener" target="_blank" href='https://www.w3.org/TR/WCAG22/'>Web Content Accessibility Guidelines (WCAG) 2.2</a> due to the non-compliances listed below.</p>
-    <h2 class="govuk-heading-m">{{#t}}accessibility.non-accessible-header{{/t}}</h2>
-    <p class="govuk-body">{{#t}}accessibility.non-accessible-p1{{/t}}</p>
-    <h3 class="govuk-heading-m">{{#t}}accessibility.non-compliance-header{{/t}}</h3>
-    <p class="govuk-body">The session timeout of 30 minutes cannot be changed, and the user is not alerted when it is running out. This is for each individual page of the form, not the form overall. This does not meet WCAG 2.2 – Enough Time.</p>
-    <p class="govuk-body">If you find an issue that we have yet to identify, please contact us using one of the routes described in the ‘Reporting accessibility problems with this website’ section of this statement.</p>
-    <h3 class="govuk-heading-m">{{#t}}accessibility.disproportionate-burden-header{{/t}}</h3>
-    <p class="govuk-body">Not applicable.</p>
-    <h3 class="govuk-heading-m">{{#t}}accessibility.outside-scope-header{{/t}}</h3>
-    <p class="govuk-body">Not applicable.</p>
+    <p class="govuk-body">This service is fully compliant with the <a class="govuk-link" rel="noreferrer noopener" target="_blank" href='https://www.w3.org/TR/WCAG22/'>Web Content Accessibility Guidelines (WCAG) 2.2</a> AA standard.</p>
     <h2 class="govuk-heading-m">{{#t}}accessibility.preparation-header{{/t}}</h2>
-    <p class="govuk-body">This statement was prepared on 1 June 2020. It was last reviewed on 16 September 2024.</p>
+    <p class="govuk-body">This statement was prepared on 1 June 2020. It was last reviewed on 05 March 2025.</p>
     <p class="govuk-body">This website was last tested on 2 April 2024. The test was carried out internally by the Home Office.</p>
     <p class="govuk-body">{{#t}}accessibility.preparation-p3{{/t}}</p>
     {{/content}}

--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
     "start": "node server.js",
     "start:dev": "NODE_ENV=development hof-build watch --env",
     "test": "npm run test:lint",
-   "test:integration": "NODE_ENV=development _mocha \"test/_integration/**/*.spec.js\" -r dotenv/config --exit",
+    "test:integration": "NODE_ENV=development _mocha \"test/_integration/**/*.spec.js\" -r dotenv/config --exit",
     "test:lint": "eslint . --config ./node_modules/eslint-config-hof/default.js",
     "build": "hof-build",
     "postinstall": "yarn run build"


### PR DESCRIPTION
## What?
Updated accessibility statement.  

## Why?
https://collaboration.homeoffice.gov.uk/jira/browse/GRO-215

## How?
- noted site is fully compliant with WCAG 2.2 AA. Deleted out of date lines (accessibility.html)
- minor formatting (package.json)

## Testing?
https://are-are-135-accessibilitystatement.internal.are-branch.homeoffice.gov.uk/accessibility.html
the accessibility statement should say that it is fully compliant with the WCAG 2.2 AA standard.  

## Screenshots (optional)
## Anything Else? (optional)
## Check list

- [X] I have reviewed my own pull request for linting issues (e.g. adding new lines)
- [ ] I have written tests (if relevant)
- [X] I have created a JIRA number for my branch
- [X] I have created a JIRA number for my commit
- [X] I have followed the chris beams method for my commit https://cbea.ms/git-commit/
here is an [example commit](https://github.com/UKHomeOfficeForms/hof/commit/810959f391187c7c4af6db262bcd143b50093a6e)
- [X] Ensure drone builds are green especially tests
- [X] I will squash the commits before merging
