### PR TITLE
GRO-263: Node image upgrade to 20.20.2

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -37,7 +37,8 @@ trivy-client-image: &trivy-client-image
 
 linting: &linting
   pull: if-not-exists
-  image: node:20.16.0-alpine3.20@sha256:eb8101caae9ac02229bd64c024919fe3d4504ff7f329da79ca60a04db08cef52
+  image: quay.io/ukhomeofficedigital/hof-nodejs:20.20.2-alpine3.23@sha256:bcd17b68a0f1910f1670b07f6a47d1e2c28291bafc219807c494dc62b57ea25e
+
   environment:
     NOTIFY_KEY: USE_MOCK
   commands:
@@ -45,7 +46,7 @@ linting: &linting
 
 unit_tests: &unit_tests
   pull: if-not-exists
-  image: node:20.16.0-alpine3.20@sha256:eb8101caae9ac02229bd64c024919fe3d4504ff7f329da79ca60a04db08cef52
+  image: quay.io/ukhomeofficedigital/hof-nodejs:20.20.2-alpine3.23@sha256:bcd17b68a0f1910f1670b07f6a47d1e2c28291bafc219807c494dc62b57ea25e
   environment:
     NOTIFY_KEY: USE_MOCK
   commands:
@@ -53,13 +54,13 @@ unit_tests: &unit_tests
 
 sonar_scanner: &sonar_scanner
   pull: if-not-exists
-  image: quay.io/ukhomeofficedigital/sonar-scanner-nodejs:latest
+  image: quay.io/ukhomeofficedigital/sonar-scanner:latest
   commands:
     - sonar-scanner -Dproject.settings=./sonar-project.properties
 
 integration_tests: &integration_tests
   pull: if-not-exists
-  image: node:20.16.0-alpine3.20@sha256:eb8101caae9ac02229bd64c024919fe3d4504ff7f329da79ca60a04db08cef52
+  image: quay.io/ukhomeofficedigital/hof-nodejs:20.20.2-alpine3.23@sha256:bcd17b68a0f1910f1670b07f6a47d1e2c28291bafc219807c494dc62b57ea25e
   environment:
     NOTIFY_KEY: USE_MOCK
 

--- a/.drone.yml
+++ b/.drone.yml
@@ -91,7 +91,7 @@ steps:
         cpu: 1000
         memory: 1024Mi
     environment:
-      IMAGE_NAME: node:20.16.0-alpine3.20@sha256:eb8101caae9ac02229bd64c024919fe3d4504ff7f329da79ca60a04db08cef52
+      IMAGE_NAME: quay.io/ukhomeofficedigital/hof-nodejs:20.20.2-alpine3.23@sha256:bcd17b68a0f1910f1670b07f6a47d1e2c28291bafc219807c494dc62b57ea25e
       SERVICE_URL: https://acp-trivy-helm.acp-trivy.svc.cluster.local:443
       SEVERITY: MEDIUM,HIGH,CRITICAL --dependency-tree
       FAIL_ON_DETECTION: false
@@ -403,7 +403,7 @@ steps:
   - name: cron_trivy_scan_image_os
     <<: *trivy-client-image
     environment:
-      IMAGE_NAME: node:20.16.0-alpine3.20@sha256:eb8101caae9ac02229bd64c024919fe3d4504ff7f329da79ca60a04db08cef52
+      IMAGE_NAME: quay.io/ukhomeofficedigital/hof-nodejs:20.20.2-alpine3.23@sha256:bcd17b68a0f1910f1670b07f6a47d1e2c28291bafc219807c494dc62b57ea25e
       SEVERITY: UNKNOWN,LOW,MEDIUM,HIGH,CRITICAL --dependency-tree
       FAIL_ON_DETECTION: true
       IGNORE_UNFIXED: false

--- a/.droneignore
+++ b/.droneignore
@@ -1,0 +1,6 @@
+node_modules
+public
+apps/**/translations/**/default.json
+LICENSE.md
+README.md
+CONTRIBUTING.md

--- a/.gitignore
+++ b/.gitignore
@@ -17,6 +17,5 @@ pdf-form-submissions/*.pdf
 !pdf-form-submissions/pdf-form-submissions-test.pdf
 coverage
 .nyc_output
-anchore-reports/
 .env
 dump.rdb

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM node:20.16.0-alpine3.20@sha256:eb8101caae9ac02229bd64c024919fe3d4504ff7f329da79ca60a04db08cef52
+FROM quay.io/ukhomeofficedigital/hof-nodejs:20.20.2-alpine3.23@sha256:bcd17b68a0f1910f1670b07f6a47d1e2c28291bafc219807c494dc62b57ea25e
 
 USER root
 


### PR DESCRIPTION
## What? 

* We are testing Node 20.20.2 . This image has fixed vulnerabilities.
* Later stages we will be replacing with the image that is tagged to the version.

## Why? 
* Node 20.19.0 has Critical, High Medium Vulnerabilities that is used by the APP.

## How? 
* Replace Node image 
* Update pipeliene to latest

## Testing?
* Testing to be done in each environment 

## Screenshots (optional)
<img width="899" height="187" alt="image" src="https://github.com/user-attachments/assets/469c29bb-0099-4f8c-aab1-a913701b57a4" />



## Anything Else? (optional)
## Check list

- [x] I have reviewed my own pull request for linting issues (e.g. adding new lines)
- [x] I have written tests (if relevant)
- [x] I have created a JIRA number for my branch
- [x] I have created a JIRA number for my commit
- [x] I have followed the chris beams method for my commit https://cbea.ms/git-commit/
here is an [example commit](https://github.com/UKHomeOfficeForms/hof/commit/810959f391187c7c4af6db262bcd143b50093a6e)
- [x] Ensure drone builds are green especially tests
- [x] I will squash the commits before merging
