### PR TITLE
GRO-211-Add-PV-dding pvc to service and testing on stg

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -419,7 +419,7 @@ steps:
     when:
       branch:
         <<: *include_default_branch
-      event: pull_request
+      event: push
     depends_on:
       - clone_repos
       - image_to_quay

--- a/.drone.yml
+++ b/.drone.yml
@@ -269,6 +269,7 @@ steps:
         from_secret: kube_server_dev
       KUBE_TOKEN:
         from_secret: kube_token_dev
+      REDIS_PERSISTENCE_ENABLED: "false"
     volumes:
       - name: dockersock
         path: /root/.dockersock
@@ -349,6 +350,7 @@ steps:
         from_secret: kube_server_dev
       KUBE_TOKEN:
         from_secret: kube_token_dev
+      REDIS_PERSISTENCE_ENABLED: "false"
     commands:
       - bin/deploy.sh $${UAT_ENV}
     when:
@@ -409,15 +411,18 @@ steps:
         from_secret: kube_server_stg
       KUBE_TOKEN:
         from_secret: kube_token_stg
+      REDIS_PERSISTENCE_ENABLED: "true"
+      REDIS_PERSISTENCE_SIZE: 1Gi
     commands:
       - bin/deploy.sh $${STG_ENV}
     when:
       branch:
         <<: *include_default_branch
-      event: push
+      event: pull_request
     depends_on:
       - clone_repos
       - image_to_quay
+      - deploy_to_branch
 
   # Checks a build being promoted has passed, is on master which effectively means a healthy build on Staging
   - name: sanity_check_build_prod
@@ -471,6 +476,8 @@ steps:
         from_secret: kube_server_prod
       KUBE_TOKEN:
         from_secret: kube_token_prod
+      REDIS_PERSISTENCE_ENABLED: "true"
+      REDIS_PERSISTENCE_SIZE: 10Gi
     commands:
       - bin/deploy.sh $${PROD_ENV}
     when:

--- a/.drone.yml
+++ b/.drone.yml
@@ -269,7 +269,8 @@ steps:
         from_secret: kube_server_dev
       KUBE_TOKEN:
         from_secret: kube_token_dev
-      REDIS_PERSISTENCE_ENABLED: "false"
+      REDIS_PERSISTENCE_ENABLED: "true"
+      REDIS_PERSISTENCE_SIZE: 1Gi
     volumes:
       - name: dockersock
         path: /root/.dockersock
@@ -422,7 +423,6 @@ steps:
     depends_on:
       - clone_repos
       - image_to_quay
-      - deploy_to_branch
 
   # Checks a build being promoted has passed, is on master which effectively means a healthy build on Staging
   - name: sanity_check_build_prod

--- a/.drone.yml
+++ b/.drone.yml
@@ -269,8 +269,7 @@ steps:
         from_secret: kube_server_dev
       KUBE_TOKEN:
         from_secret: kube_token_dev
-      REDIS_PERSISTENCE_ENABLED: "true"
-      REDIS_PERSISTENCE_SIZE: 1Gi
+      REDIS_PERSISTENCE_ENABLED: "false"
     volumes:
       - name: dockersock
         path: /root/.dockersock

--- a/bin/deploy.sh
+++ b/bin/deploy.sh
@@ -8,33 +8,77 @@ export NGINX_SETTINGS=$HOF_CONFIG/nginx-settings.yaml
 
 kd='kd --insecure-skip-tls-verify --timeout 10m --check-interval 10s'
 
+deploy_redis() {
+  if [[ "${REDIS_PERSISTENCE_ENABLED}" == "true" && -z "${REDIS_PERSISTENCE_EXISTING_CLAIM}" ]]; then
+    $kd -f kube/redis/redis-pvc.yml
+  fi
+
+  $kd -f kube/redis/redis-service.yml -f kube/redis/redis-network-policy.yml -f kube/redis/redis-deployment.yml
+}
+
+delete_redis() {
+  if [[ "${REDIS_PERSISTENCE_ENABLED}" == "true" && -z "${REDIS_PERSISTENCE_EXISTING_CLAIM}" ]]; then
+    $kd --delete -f kube/redis/redis-pvc.yml
+  fi
+
+  $kd --delete -f kube/redis/redis-service.yml -f kube/redis/redis-network-policy.yml -f kube/redis/redis-deployment.yml
+}
+
+configure_redis_persistence() {
+  export REDIS_PERSISTENCE_ENABLED=${REDIS_PERSISTENCE_ENABLED:-false}
+  export REDIS_PERSISTENCE_ACCESS_MODES=${REDIS_PERSISTENCE_ACCESS_MODES:-ReadWriteOnce}
+  export REDIS_PERSISTENCE_STORAGE_CLASS=${REDIS_PERSISTENCE_STORAGE_CLASS:-gp2-encrypted}
+  export REDIS_PERSISTENCE_EXISTING_CLAIM=${REDIS_PERSISTENCE_EXISTING_CLAIM:-}
+  export REDIS_PERSISTENCE_SIZE=${REDIS_PERSISTENCE_SIZE:-1Gi}
+
+  REDIS_PERSISTENCE_ENABLED=$(echo "${REDIS_PERSISTENCE_ENABLED}" | tr '[:upper:]' '[:lower:]')
+  export REDIS_PERSISTENCE_ENABLED
+
+  if [[ ${KUBE_NAMESPACE} == ${PROD_ENV} ]]; then
+    export REDIS_PERSISTENCE_ENABLED=true
+    export REDIS_PERSISTENCE_SIZE=10Gi
+  elif [[ ${KUBE_NAMESPACE} == ${STG_ENV} ]]; then
+    export REDIS_PERSISTENCE_ENABLED=true
+    export REDIS_PERSISTENCE_SIZE=1Gi
+  else
+    export REDIS_PERSISTENCE_ENABLED=false
+  fi
+}
+
 if [[ $1 == 'tear_down' ]]; then
   export KUBE_NAMESPACE=$BRANCH_ENV
   export DRONE_SOURCE_BRANCH=$(cat /root/.dockersock/branch_name.txt)
+  configure_redis_persistence
 
   $kd --delete -f kube/configmaps/configmap.yml
-  $kd --delete -f kube/redis -f kube/app
+  delete_redis
+  $kd --delete -f kube/app
   echo "Torn Down Branch - $APP_NAME-$DRONE_SOURCE_BRANCH.internal.$BRANCH_ENV.homeoffice.gov.uk"
   exit 0
 fi
 
 export KUBE_NAMESPACE=$1
 export DRONE_SOURCE_BRANCH=$(echo $DRONE_SOURCE_BRANCH | tr '[:upper:]' '[:lower:]' | tr '/' '-')
+configure_redis_persistence
 
 if [[ ${KUBE_NAMESPACE} == ${BRANCH_ENV} ]]; then
   $kd -f kube/configmaps -f kube/certs
-  $kd -f kube/redis -f kube/app
+  deploy_redis
+  $kd -f kube/app
 elif [[ ${KUBE_NAMESPACE} == ${UAT_ENV} ]]; then
   $kd -f kube/configmaps/configmap.yml
-  $kd -f kube/redis -f kube/app
+  deploy_redis
+  $kd -f kube/app
 elif [[ ${KUBE_NAMESPACE} == ${STG_ENV} ]]; then
   $kd -f kube/configmaps/configmap.yml -f kube/app/service.yml
   $kd -f kube/app/networkpolicy-internal.yml -f kube/app/ingress-internal.yml
-  $kd -f kube/redis -f kube/app/deployment.yml
+  deploy_redis
+  $kd -f kube/app/deployment.yml
 elif [[ ${KUBE_NAMESPACE} == ${PROD_ENV} ]]; then
   $kd -f kube/configmaps/configmap.yml -f kube/app/service.yml
   $kd -f kube/app/networkpolicy-external.yml -f kube/app/ingress-external.yml
-  $kd -f kube/redis -f kube/app/deployment.yml
+  deploy_redis
+  $kd -f kube/app/deployment.yml
 fi
 
 sleep $READY_FOR_TEST_DELAY

--- a/bin/deploy.sh
+++ b/bin/deploy.sh
@@ -40,6 +40,9 @@ configure_redis_persistence() {
   elif [[ ${KUBE_NAMESPACE} == ${STG_ENV} ]]; then
     export REDIS_PERSISTENCE_ENABLED=true
     export REDIS_PERSISTENCE_SIZE=1Gi
+  elif [[ ${KUBE_NAMESPACE} == ${BRANCH_ENV} ]]; then
+    export REDIS_PERSISTENCE_ENABLED=true
+    export REDIS_PERSISTENCE_SIZE=1Gi
   else
     export REDIS_PERSISTENCE_ENABLED=false
   fi

--- a/bin/deploy.sh
+++ b/bin/deploy.sh
@@ -40,9 +40,6 @@ configure_redis_persistence() {
   elif [[ ${KUBE_NAMESPACE} == ${STG_ENV} ]]; then
     export REDIS_PERSISTENCE_ENABLED=true
     export REDIS_PERSISTENCE_SIZE=1Gi
-  elif [[ ${KUBE_NAMESPACE} == ${BRANCH_ENV} ]]; then
-    export REDIS_PERSISTENCE_ENABLED=true
-    export REDIS_PERSISTENCE_SIZE=1Gi
   else
     export REDIS_PERSISTENCE_ENABLED=false
   fi

--- a/kube/redis/redis-deployment.yml
+++ b/kube/redis/redis-deployment.yml
@@ -8,6 +8,8 @@ metadata:
   name: redis
   {{ end }}
 spec:
+  strategy:
+    type: Recreate
   replicas: 1
   selector:
     matchLabels:
@@ -29,14 +31,24 @@ spec:
         app: redis
         {{ end }}
     spec:
+      securityContext:
+        fsGroup: 999
       containers:
         - name: redis
           # redis:v7.0.15
           image: quay.io/ukhomeofficedigital/hof-docker-redis:7.0.15@sha256:cd4965fbb8aa6e4eba058985cc52f6a3ececdfa6d79ba44206f051f72a1f0611
+          args:
+            - redis-server
+            - --appendonly
+            - "yes"
+            - --dir
+            - /data
+            - --protected-mode
+            - "no"
           ports:
             - containerPort: 6379
           volumeMounts:
-            - mountPath: /var/lib/redis
+            - mountPath: /data
               name: data
           securityContext:
             runAsNonRoot: true
@@ -48,5 +60,19 @@ spec:
               cpu: "100m"
               memory: "200Mi"
       volumes:
+        {{ if and (eq .REDIS_PERSISTENCE_ENABLED "true") (eq .REDIS_PERSISTENCE_EXISTING_CLAIM "") }}
+        - name: data
+          persistentVolumeClaim:
+            {{ if eq .KUBE_NAMESPACE .BRANCH_ENV }}
+            claimName: redis-data-{{ .DRONE_SOURCE_BRANCH }}
+            {{ else }}
+            claimName: redis-data
+            {{ end }}
+        {{ else if ne .REDIS_PERSISTENCE_EXISTING_CLAIM "" }}
+        - name: data
+          persistentVolumeClaim:
+            claimName: {{ .REDIS_PERSISTENCE_EXISTING_CLAIM }}
+        {{ else }}
         - name: data
           emptyDir: {}
+        {{ end }}

--- a/kube/redis/redis-pvc.yml
+++ b/kube/redis/redis-pvc.yml
@@ -1,0 +1,16 @@
+---
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  {{ if eq .KUBE_NAMESPACE .BRANCH_ENV }}
+  name: redis-data-{{ .DRONE_SOURCE_BRANCH }}
+  {{ else }}
+  name: redis-data
+  {{ end }}
+spec:
+  accessModes:
+    - {{ .REDIS_PERSISTENCE_ACCESS_MODES }}
+  storageClassName: {{ .REDIS_PERSISTENCE_STORAGE_CLASS }}
+  resources:
+    requests:
+      storage: {{ .REDIS_PERSISTENCE_SIZE }}


### PR DESCRIPTION
## What?
This pull request introduces several improvements to how Redis is deployed and managed in the Kubernetes environment, focusing on enabling and configuring persistent storage for Redis across various environments. It also makes the deployment more robust and secure by updating deployment strategies and container settings.

**Persistent storage configuration for Redis:**

* Added support for enabling/disabling Redis persistence via the `REDIS_PERSISTENCE_ENABLED` environment variable in `.drone.yml`, with environment-specific settings for storage size and class. [[1]](diffhunk://#diff-b54b39f1afced2465e1f3641db9d5bbf4f3a7fcf890996dfedd3c197bcb7f8c7R235) [[2]](diffhunk://#diff-b54b39f1afced2465e1f3641db9d5bbf4f3a7fcf890996dfedd3c197bcb7f8c7R255) [[3]](diffhunk://#diff-b54b39f1afced2465e1f3641db9d5bbf4f3a7fcf890996dfedd3c197bcb7f8c7R315-R328) [[4]](diffhunk://#diff-b54b39f1afced2465e1f3641db9d5bbf4f3a7fcf890996dfedd3c197bcb7f8c7R368-R371)
* Introduced a new `kube/redis/redis-pvc.yml` file to define a `PersistentVolumeClaim` for Redis, parameterized by environment and storage requirements.
* Updated volume mounting in `redis-deployment.yml` to use a persistent volume claim when persistence is enabled, otherwise defaulting to `emptyDir`.

**Redis deployment and security enhancements:**

* Changed the Redis deployment strategy to `Recreate` to ensure safe updates when persistent storage is in use.
* Updated the Redis container configuration to run with a specific `fsGroup`, use `/data` for persistence, and enable append-only file mode for data durability.

These changes improve data durability for Redis, make deployments safer and more predictable, and provide flexibility for different deployment environments.

## Why?
To ensure the data persists

## How?
Add PVC

## Testing?
Manual

## Screenshots (optional)
## Anything Else? (optional)
## Check list

- [ ] I have reviewed my own pull request for linting issues (e.g. adding new lines)
- [ ] I have written tests (if relevant)
- [ ] I have created a JIRA number for my branch
- [ ] I have created a JIRA number for my commit
- [ ] I have followed the chris beams method for my commit https://cbea.ms/git-commit/
here is an [example commit](https://github.com/UKHomeOfficeForms/hof/commit/810959f391187c7c4af6db262bcd143b50093a6e)
- [ ] Ensure drone builds are green especially tests
- [ ] I will squash the commits before merging
